### PR TITLE
test(robustness): fault-injection harness + feature-robustness plan

### DIFF
--- a/.loom/00-index.md
+++ b/.loom/00-index.md
@@ -8,6 +8,7 @@
 - Product spec: `20-product-spec.md`
 - **Implementation plan: `30-implementation-plan.md`** - M0-M16 milestone plan
 - **M16 issue checklist: `31-m16-issue-checklist.md`** - PR-sized execution board
+- **Feature robustness plan: `60-plan-feature-robustness-2026-06-23.md`** - Full-stack vertical hardening (resilience/validation/testing/security); store plan_id `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3`. Kill-test results: `robustness-killtest-notes.md`.
 - **Decisions: `40-decisions.md`** - Go-first, archive aspirational specs, keep agents
 - Worklog: `50-worklog.md`
 

--- a/.loom/60-plan-feature-robustness-2026-06-23.md
+++ b/.loom/60-plan-feature-robustness-2026-06-23.md
@@ -1,0 +1,154 @@
+# MentatLab Feature Robustness (Full-Stack Vertical Hardening)
+
+- **Plan ID**: `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3`
+- **Phase**: draft
+- **Project**: services/mentatlab
+- **Namespace**: mentatlab/feature-robustness
+- **Created by**: claude-code
+- **Created**: 2026-06-23T09:18:55Z
+- **Updated**: 2026-06-23T10:27:16Z
+
+> Rendered from the Loom plan store (canonical). Edit via `agent_plan_*` tools, not this file.
+
+## Spec
+
+## Summary
+
+Harden MentatLab's flagship user journeys **end-to-end** (frontend → gateway → orchestrator → agent) across four robustness dimensions: **runtime resilience**, **live validation**, **test & regression safety**, and **security**. Approach is *full-stack vertical*: rather than horizontal sweeps, we pick a small number of flagship journeys and make each bulletproof through all four dimensions, proving the fix with a fault-injection harness.
+
+Flagship journeys:
+- **J1 — Core run loop**: build flow → create run → schedule DAG → execute agent (subprocess/K8s) → stream events (SSE/WS) → render in Mission Control. *The* flagship; everything else builds on it.
+- **J2 — Gated/approval workflow**: gate node blocks → operator approves/rejects via API → downstream resumes.
+- **J3 — Triggered runs**: webhook + cron auto-create and start runs.
+
+## Riskiest assumption + kill-test
+
+**Load-bearing assumption**: MentatLab's persistence layer does **not** actually preserve in-flight run state across an orchestrator restart, and live event streams (SSE) silently lose events under disconnect/backpressure — i.e. the resilience gaps found by static analysis are real and reproducible, not masked by some recovery path the static read missed. The entire resilience track (Slices 1, 4, 5) is sized against these being true.
+
+**Kill test** (Slice 0, ≤30 min, run on docker-compose stack with Redis):
+1. Start the full stack, create a flow with a long-running agent node (e.g. a 60s sleep agent), start a run, confirm it is `running` and emitting events.
+2. `kill -TERM` the orchestrator mid-run.
+3. Observe: does the run resume/recover, get marked failed cleanly, or vanish? Query `GET /api/v1/runs/{id}` and `/events` after restart.
+4. Separately: subscribe to SSE, force a client disconnect during high event volume, reconnect with `Last-Event-ID`, and diff received event IDs against the orchestrator's stored stream to detect drops/gaps.
+
+**Observable outcome**: a written record of exactly what happens to an in-flight run on restart and whether SSE resumption is lossless. If runs vanish / SSE gaps appear → assumption confirmed. If runs recover cleanly and SSE is lossless → assumption FALSE, de-scope Slice 1 durability work.
+
+**Failure mode if wrong**: we'd build run-recovery machinery for a system that already recovers, wasting the largest resilience slice.
+
+**Status**: **PASSED / CONFIRMED 2026-06-23** — see `.loom/robustness-killtest-notes.md`.
+- Restart, `redis` store: run state persists but becomes an orphaned `running` zombie (no resume, no clean-fail).
+- Restart, `memory` store (the silent-fallback target): run vanishes entirely (HTTP 404).
+- SSE: losslessness *could not be measured* because live testing found two worse P0 bugs — (1) orchestrator SSE returns 500 everywhere (`responseWriter` middleware strips `http.Flusher`, `internal/api/middleware.go:146`); (2) SSE reconnect panics the whole orchestrator (`send on closed channel`, `internal/runstore/redis.go:962`). Plus Redis-URL db-index parsing is inconsistent across stores → silent memory fallback. These are folded into Slice 1.
+
+## Evidence base (static analysis, 2026-06-23)
+
+Resilience (orchestrator-go):
+- Silent in-memory fallback masks Redis loss; state lost on restart — `internal/factories/factories.go:32-52`, `:83-114`
+- State writes dropped when circuit breaker open, no buffer/WAL — `internal/runstore/redis.go:194-263`
+- SSE events silently skipped when channel full — `internal/api/sse.go` + `internal/runstore/redis.go:967`; stream hard-trimmed at MaxLen=5000 — `redis.go:799-806`
+- K8s job watch restarts without resourceVersion → misses completion events — `internal/k8s/watch.go:71-124`
+- Heartbeat-timeout job deletion error ignored, uses background ctx — `internal/driver/k8s.go:187-210`
+- No scheduler drain on shutdown — `cmd/orchestrator/main.go:260-284`
+
+Live-confirmed bugs (kill-test, 2026-06-23) — see `.loom/robustness-killtest-notes.md`:
+- SSE 500 everywhere: `responseWriter` (middleware.go:146, used by Logging+Audit per routes.go:61,144) strips `http.Flusher`.
+- SSE reconnect panics orchestrator: `send on closed channel` at `internal/runstore/redis.go:962` (Subscribe.cleanup close-before-exit race).
+- Redis URL db-index parsing inconsistent: runstore parses `redis://host:6379/15`; registry+flowstore fail and silently fall back to memory.
+- No run recovery on restart (redis: zombie `running`; memory: vanishes).
+- No compose image can execute bundled agents (orchestrator image lacks Python) — compose e2e never exercises real subprocess execution.
+
+Testing:
+- Zero unit tests: scheduler core (12 files), API handlers (17 files incl `sse.go`, `routes.go`, validation), `runstore/{store,memory,redis}.go`, `flowstore/{store,redis}.go`, driver (5 files)
+- Frontend untested: `services/streaming/{orchestratorSSE,parse,streamRegistry,workerManager}.ts`, `transport/event-pipeline.ts`, `services/api/{httpClient,websocketClient,streamingService}.ts`
+- CI: coverage regex is informational only, no `--fail-under`; no load/chaos/e2e-depth gates — `.gitlab-ci.yml`
+
+Security:
+- API-key scopes stored but never enforced per-endpoint — `internal/auth/apikey.go:22-30`, `internal/auth/middleware.go:96-112`
+- Agent secrets passed as plaintext env (no K8s Secrets) — `internal/k8s/job.go:122-129`, `internal/driver/subprocess.go:59-72`
+- Subprocess driver has no resource/isolation limits — `internal/driver/subprocess.go`
+- (Already solid: audit logging `internal/api/audit.go`; K8s securityContext + NetworkPolicy `k8s/job.go:163-183`, `k8s/network-policies.yaml:313-356`)
+
+Live validation (coded, unproven e2e): K8s job driver, MinIO/S3 dataflow (`internal/dataflow/s3.go`, feature-flagged, not wired into run outputs), gates/webhooks/cron (`internal/api/handlers_m5m6.go`, `internal/scheduler/{gate,cron}.go`), MCP node exec + agent-context (`internal/mcpclient/hub.go`, `agents/common/context.py`).
+
+## Non-Goals
+
+- New orchestration features. This is hardening of existing features only.
+- Frontend visual redesign (M16 owns that).
+- Rewriting the persistence or scheduler architecture from scratch — incremental, test-gated changes only.
+- TypeScript SDK / checkpoint-resume feature build-out beyond what existing journeys already use.
+
+## Success Criteria
+
+1. Kill-test run and recorded; resilience scope confirmed or re-pointed. ✅ (CONFIRMED 2026-06-23)
+2. An in-flight run survives an orchestrator restart with a deterministic, documented outcome (recover or clean-fail — no silent vanish), and SSE resumption is lossless within the retained window.
+3. CI enforces a coverage floor on orchestrator-go + gateway-go + frontend; the previously-zero-coverage critical packages (scheduler, runstore, sse, frontend streaming) have meaningful tests.
+4. Each flagship journey (J1/J2/J3) has a live e2e test running against a real stack in CI.
+5. API-key scopes are enforced per-endpoint; agent secrets flow via K8s Secrets, not plaintext env.
+
+## Slices
+
+### 1. Slice 0 — Fault-injection harness + kill-test — `implemented`
+
+- **Slice ID**: `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#1`
+- **Goal**: Build a reproducible chaos/fault-injection harness on the docker-compose stack and run the riskiest-assumption kill-test: does an in-flight run survive an orchestrator restart, and is SSE resumption lossless? Record the observed outcome and confirm or re-point the resilience scope (gates Slice 1).
+- **Files**: docker-compose.yml, docker-compose.ci.yml, agents/sleep/main.py, scripts/chaos/restart-midrun.sh, scripts/chaos/sse-gap-check.mjs, .loom/robustness-killtest-notes.md
+- **Branch**: test/robustness-fault-harness
+- **Acceptance**: 1) A long-running test agent (configurable sleep) exists and can be scheduled. 2) `scripts/chaos/restart-midrun.sh` starts a run, restarts orchestrator mid-run, and reports the run's post-restart status from the API. 3) `scripts/chaos/sse-gap-check.mjs` subscribes to SSE, forces a disconnect under load, reconnects with Last-Event-ID, and reports any event-ID gaps. 4) Outcome written to `.loom/robustness-killtest-notes.md` with verdict: resilience scope CONFIRMED or RE-POINTED. 5) Plan riskiest-assumption Status updated to passed/FAILED with date.
+- **Decision**: DONE 2026-06-23. Harness built (agents/sleep/main.py, scripts/chaos/restart-midrun.sh, scripts/chaos/sse-gap-check.mjs) and kill-test executed. Verdict: ASSUMPTION CONFIRMED. Results + 3 discovered P0/parsing bugs in .loom/robustness-killtest-notes.md. Note: docker-compose orchestrator image cannot execute bundled agents (no python), so harness runs orchestrator natively — flagged for Slice 3 (need a real agent-exec image for honest e2e).
+
+### 2. Slice 1 — J1 core run loop: durability & resilience — `implementing`
+
+- **Slice ID**: `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#2`
+- **Goal**: Make the core run loop survive infrastructure faults deterministically. Eliminate silent data loss: make the memory fallback explicit/alerting (not a silent default), recover or cleanly fail in-flight runs on orchestrator restart, buffer/retry state writes when Redis is briefly unavailable, ensure SSE resumption is lossless within the retained window, and drain the scheduler on shutdown.
+- **Files**: services/orchestrator-go/internal/factories/factories.go, services/orchestrator-go/internal/runstore/redis.go, services/orchestrator-go/internal/runstore/store.go, services/orchestrator-go/internal/api/sse.go, services/orchestrator-go/internal/k8s/watch.go, services/orchestrator-go/internal/driver/k8s.go, services/orchestrator-go/cmd/orchestrator/main.go, services/orchestrator-go/internal/scheduler/run_lifecycle.go
+- **Branch**: feat/robustness-runloop-durability
+- **Depends on**: plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#1
+- **Acceptance**: 1) Memory fallback requires explicit ORCH_ALLOW_MEMORY_FALLBACK and emits a loud, repeated WARN + metric; default behavior fails fast. 2) On orchestrator restart with Redis backing, in-flight runs are either resumed or transitioned to a terminal failed state with a reason — never silently lost (verified by Slice 0 harness). 3) State writes during a transient Redis outage are retried/buffered, not dropped on circuit-breaker-open. 4) SSE Last-Event-ID resumption returns no gaps within the retained stream window; trimming is observable (metric/log) so clients can detect it. 5) K8s job watch resumes from resourceVersion and does not miss completion events across an API flap. 6) Heartbeat-timeout job deletion uses a bounded context and retries; failures surface. 7) SIGTERM drains the scheduler (bounded) before stores close. 8) Slice 0 harness reruns green for restart + SSE scenarios.
+- **MR**: https://github.com/flexinfer/mentatlab/pull/3
+- **Decision**: Kill-test (Slice 0) confirmed scope and surfaced 4 concrete must-fix items for this slice, some not in the original static list: (1) SSE returns 500 everywhere — responseWriter middleware (middleware.go:146, used by Logging+Audit) strips http.Flusher; minimal Flush() passthrough already applied in working tree, needs regression test. (2) SSE reconnect panics whole orchestrator 'send on closed channel' redis.go:962 — Subscribe.cleanup() closes ch while streamReader still sending; close-before-goroutine-exit race. (3) Redis URL db-index parsing inconsistent: runstore parses redis://host:6379/15, registry+flowstore fail and silently fall back to memory — unify parsing AND make fallback loud. (4) Run recovery on restart: redis-backed in-flight runs zombie as 'running' forever (no resume); must either resume or mark failed-with-reason. Add files: internal/api/middleware.go. Evidence: .loom/robustness-killtest-notes.md
+- **Decision**: PARTIAL: shipped + merged (PR #3) the two P0 SSE fixes discovered by the kill-test — (1) responseWriter Flush() passthrough (SSE no longer 500s); (2) Subscribe/streamReader close-before-exit fix (no more 'send on closed channel' panic on reconnect). Both have regression tests (incl -race); full orchestrator-go suite green; verified live (0 panics, lossless Last-Event-ID resumption). STILL PENDING for this slice: memory-fallback gating (explicit ORCH_ALLOW_MEMORY_FALLBACK + loud warn/metric, fail-fast default), run recovery on restart (resume or mark-failed; no 'running' zombies), Redis write retry/buffer on circuit-breaker-open, unified Redis URL db-index parsing across runstore/registry/flowstore, K8s watch resourceVersion resume, heartbeat-timeout bounded ctx, scheduler drain on SIGTERM.
+
+### 3. Slice 2 — J1 core run loop: test & regression safety — `pending`
+
+- **Slice ID**: `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#3`
+- **Goal**: Close the zero-coverage gaps on the code paths the core run loop depends on, and turn on enforcement so coverage can't silently regress. Target the highest-risk untested units: runstore/flowstore (memory↔redis parity), scheduler core, SSE handler, and frontend streaming/event-pipeline.
+- **Files**: services/orchestrator-go/internal/runstore/redis_test.go, services/orchestrator-go/internal/runstore/memory_test.go, services/orchestrator-go/internal/flowstore/redis_test.go, services/orchestrator-go/internal/scheduler/scheduler_test.go, services/orchestrator-go/internal/scheduler/run_lifecycle_test.go, services/orchestrator-go/internal/api/sse_test.go, services/frontend/src/services/streaming/orchestratorSSE.test.ts, services/frontend/src/services/streaming/parse.test.ts, services/frontend/src/transport/event-pipeline.test.ts, .gitlab-ci.yml
+- **Branch**: test/robustness-runloop-coverage
+- **Depends on**: plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#2
+- **Acceptance**: 1) runstore + flowstore have parity tests proving memory and redis backends behave identically for the core operations (create/get/update/events). 2) scheduler core + run lifecycle have tests covering success, node failure, retry, and partial-DAG-failure propagation. 3) SSE handler has tests for Last-Event-ID resumption and disconnect handling. 4) Frontend orchestratorSSE/parse/event-pipeline have tests for event ordering, malformed events, and reconnection. 5) CI enforces a coverage floor (`go test -coverprofile` with a fail-under check on orchestrator-go + gateway-go; vitest threshold on frontend) — builds fail below floor. 6) New tests run in CI and pass.
+
+### 4. Slice 3 — J1 core run loop: live validation in CI — `pending`
+
+- **Slice ID**: `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#4`
+- **Goal**: Prove the core run loop works against a real stack, not just mocks, and gate it in CI. Validate the K8s job driver end-to-end, the subprocess heartbeat-timeout kill path, and the MinIO/S3 artifact round-trip (wiring it into run outputs if not already). Promote the Slice 0 harness into a CI e2e/chaos job.
+- **Files**: services/orchestrator-go/internal/driver/k8s_integration_test.go, services/orchestrator-go/internal/dataflow/s3_integration_test.go, services/orchestrator-go/internal/scheduler/node_exec.go, services/frontend/e2e/orchestrator-live.spec.ts, .gitlab-ci.yml, docker-compose.ci.yml
+- **Branch**: test/robustness-runloop-e2e
+- **Depends on**: plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#1
+- **Acceptance**: 1) K8s job driver runs a real job against a Kind/k3s cluster in CI: job created, logs streamed, exit code + events captured, securityContext applied. 2) Subprocess + K8s heartbeat-timeout e2e: an agent that stops emitting heartbeats is killed and the node reports heartbeat_timeout with no zombie job. 3) MinIO artifact round-trip e2e: a run with an artifact output uploads to MinIO and a downstream node reads it back (DATAFLOW_TYPE=minio); wire artifact outputs into run outputs if currently only infra. 4) Playwright live spec covers build→run→SSE→completion against the docker-compose stack. 5) A CI e2e/chaos stage runs these against ephemeral infra and gates merges. 6) Failures produce useful artifacts (logs, screenshots).
+
+### 5. Slice 4 — J2 gated/approval workflow hardening — `pending`
+
+- **Slice ID**: `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#5`
+- **Goal**: Harden the gate/approval journey across all four dimensions: a waiting gate must survive an orchestrator restart (durability), approve/reject must be proven e2e (live validation), the gate state machine + timeout must be unit-tested (regression safety), and gate decisions must be authorized + audited (security).
+- **Files**: services/orchestrator-go/internal/scheduler/gate.go, services/orchestrator-go/internal/api/handlers_m5m6.go, services/orchestrator-go/internal/scheduler/gate_test.go, services/orchestrator-go/internal/api/handlers_m5m6_test.go, services/frontend/e2e/gate-approval.spec.ts
+- **Branch**: feat/robustness-gates
+- **Depends on**: plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#2
+- **Acceptance**: 1) A run waiting on a gate survives orchestrator restart: gate state is reconstructed from the store and approve/reject still works (no in-memory-only channel that evaporates). 2) Gate timeout behavior is deterministic and tested (timeout → reject/fail with reason). 3) Unit tests cover approve, reject, timeout, double-approve, and approve-after-restart. 4) e2e: create run with gate node → node enters waiting_approval → approve via API → downstream executes; and the reject path blocks downstream. 5) Approve/reject require appropriate scope (ties into Slice 6) and emit audit entries (verify existing audit path fires).
+
+### 6. Slice 5 — J3 triggered runs hardening (webhook + cron) — `pending`
+
+- **Slice ID**: `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#6`
+- **Goal**: Harden automated run triggers. Webhook: tighten token auth (rejection paths, rotation) and prove e2e. Cron: make scheduling durable across restart (no missed/duplicate triggers, defined catch-up behavior) and prove a schedule fires. Add the missing tests for both.
+- **Files**: services/orchestrator-go/internal/scheduler/cron.go, services/orchestrator-go/internal/api/handlers_m5m6.go, services/orchestrator-go/internal/scheduler/cron_test.go, services/orchestrator-go/internal/api/webhook_test.go
+- **Branch**: feat/robustness-triggers
+- **Depends on**: plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#2
+- **Acceptance**: 1) Webhook trigger rejects missing/invalid tokens with 403 (tested) and supports token rotation via an endpoint. 2) Cron schedules are persisted and re-loaded on restart; behavior for ticks missed during downtime is defined and tested (skip vs catch-up). 3) No duplicate triggers when multiple orchestrator replicas run (or single-runner invariant is documented + enforced). 4) Unit tests cover cron parsing/matching edge cases (already partially present — extend to restart + missed-tick) and webhook auth paths. 5) e2e: a near-term schedule fires and creates a run; a webhook POST with a valid token starts a run.
+
+### 7. Slice 6 — Cross-cutting security hardening — `pending`
+
+- **Slice ID**: `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#7`
+- **Goal**: Close the two platform-wide security gaps that make features unsafe to expose: enforce API-key scopes per-endpoint (they're stored but ignored today), and stop passing agent secrets as plaintext env (route through K8s Secrets). Add subprocess resource limits or gate untrusted execution to the K8s driver, and add dependency/secret scanning to CI.
+- **Files**: services/orchestrator-go/internal/auth/middleware.go, services/orchestrator-go/internal/auth/apikey.go, services/orchestrator-go/internal/api/routes.go, services/orchestrator-go/internal/k8s/job.go, services/orchestrator-go/internal/driver/subprocess.go, services/orchestrator-go/internal/auth/middleware_test.go, .gitlab-ci.yml
+- **Branch**: feat/robustness-security
+- **Depends on**: plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3#3
+- **Acceptance**: 1) Per-endpoint scope enforcement: a read-scoped API key is rejected (403) on write endpoints; required scopes defined per route and tested. 2) Agent secrets delivered via K8s Secrets (mounted env/files), not inline plaintext in the Job spec; secret values redacted from logs. 3) Subprocess driver enforces resource limits (cgroup/ulimit) OR untrusted agents are required to run via the K8s driver (documented + enforced). 4) CI adds dependency vulnerability scanning and secret scanning as gates. 5) Existing audit logging confirmed to cover the newly-guarded actions. 6) Scope-enforcement unit tests pass and are wired into CI.

--- a/.loom/robustness-killtest-notes.md
+++ b/.loom/robustness-killtest-notes.md
@@ -1,0 +1,51 @@
+# Robustness Kill-Test — Results (Slice 0)
+
+- **Plan**: `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3`
+- **Date run**: 2026-06-23
+- **Harness**: native `go build` orchestrator + host Python agent (`agents/sleep/main.py`), local Redis on `:6379`.
+- **Scripts**: `scripts/chaos/restart-midrun.sh`, `scripts/chaos/sse-gap-check.mjs`
+- **Verdict**: **ASSUMPTION CONFIRMED** — proceed with full resilience scope (Slice 1). Static analysis *under-counted* the problem; live testing found additional P0 bugs.
+
+## Why native, not docker-compose
+
+The stock orchestrator image (`services/orchestrator-go/Dockerfile`) is minimal alpine with **no Python and no `agents/` dir**, so the subprocess driver cannot execute Python agents in compose — the existing e2e drives runs via manually-posted checkpoints, not real agent execution. Running the orchestrator natively gives real subprocess agent execution + direct `kill -TERM`/restart against the same Redis. (Finding in its own right: there is no compose image that can actually execute the bundled agents.)
+
+## Part A — In-flight run survives orchestrator restart?
+
+Procedure: start orchestrator, create+auto-start a run whose single node runs `sleep` agent (45s), confirm `running`, `kill -TERM` orchestrator mid-run, restart against same store, query run.
+
+| Store mode | Post-restart `GET /runs/{id}` | Observed |
+|---|---|---|
+| `redis` | **HTTP 200, status `running`** (frozen) | State persists, but run is **never resumed and never cleanly failed**. `updated_at` stays at original start; node child process died with the old orchestrator. Orphaned "running" zombie indefinitely. |
+| `memory` (the silent-fallback target) | **HTTP 404** | Run **vanished entirely** — total data loss. |
+
+**Conclusion**: in-flight runs do **not** survive a restart with any deterministic, recoverable outcome. With Redis they zombie as `running` forever (no resume-on-restart machinery); with the in-memory store (which the silent fallback selects) they disappear. Confirms resilience findings #2 (silent fallback) and the absence of run recovery.
+
+## Part B — SSE resumption lossless? (could not measure — found worse)
+
+While building the SSE gap-checker, the live path surfaced **two additional P0 bugs** that block measurement and crash the service:
+
+### B1 — Orchestrator SSE returns HTTP 500 in every environment (FIXED to proceed)
+- **Symptom**: `GET /api/v1/runs/{id}/events` → `500 {"message":"streaming not supported"}`.
+- **Root cause**: the status-capturing `responseWriter` (single type in `internal/api/middleware.go:146`, used by both `LoggingMiddleware` and `AuditMiddleware` per `internal/api/routes.go:61,144`) embeds the `http.ResponseWriter` *interface* and overrides `WriteHeader`, but does **not** implement `Flush()`. `Flush` is not part of the `http.ResponseWriter` interface, so the wrapper fails the `w.(http.Flusher)` assertion in `internal/api/sse.go:64`.
+- **Impact**: orchestrator SSE is non-functional anywhere these middlewares are active (always). The frontend's reliance on this path is unvalidated; this is the "code-complete but never validated live" gap the plan predicted.
+- **Action taken**: applied a minimal `Flush()` passthrough to `responseWriter` so the kill-test could proceed. **This fix is uncommitted and needs a regression test — formalize in Slice 1.**
+
+### B2 — SSE reconnect panics and crashes the whole orchestrator
+- **Symptom**: after a client disconnects and a second client connects to the same run, the process dies with:
+  `panic: send on closed channel` at `internal/runstore/redis.go:962` (in `streamReader`, created by `Subscribe` at `:900`).
+- **Root cause**: `Subscribe`'s `cleanup()` (`redis.go:902-910`) `close(ch)`s while the `streamReader` goroutine may still be in `case ch <- event:`. The `<-ctx.Done()` guard races with `cleanup()` and loses. Close-before-goroutine-exit.
+- **Impact**: a single client reconnecting takes down the orchestrator for **all** runs. Far more severe than the "events silently dropped" static finding. SSE losslessness is moot until this is fixed.
+
+### B3 — Inconsistent Redis URL db-index parsing → silent memory fallback (bonus)
+- With `REDIS_URL=redis://localhost:6379/15`, the **runstore** parsed the `/15` DB index correctly, but the **registry** and **flow store** failed (`unknown port: lookup tcp/6379/15`) and **silently fell back to memory** (`orch-sse3.log`). A live reproduction of the silent-fallback resilience gap, plus a parsing inconsistency across stores.
+
+## Net effect on the plan
+
+- **Riskiest assumption → CONFIRMED (passed 2026-06-23).** Resilience scope (Slice 1, and the durability portions of Slices 4/5) stands.
+- **New must-fix items for Slice 1** (discovered live, not in original static list):
+  1. SSE `Flush()` passthrough on `responseWriter` (+ regression test). *(temporary fix already in working tree)*
+  2. `streamReader`/`Subscribe` close-before-exit panic on reconnect (`redis.go:900-962`).
+  3. Redis URL DB-index parsing unified across runstore/registry/flowstore (and the silent fallback made loud).
+  4. Run recovery on restart: resume in-flight runs, or mark them failed with a reason — never leave `running` zombies.
+- **New finding for Slice 3 (live validation)**: there is no container image capable of executing bundled agents; the compose e2e never exercises real subprocess agent execution. A real execution image/path is needed for honest e2e.

--- a/agents/sleep/main.py
+++ b/agents/sleep/main.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Long-running test agent for the robustness fault-injection harness.
+
+Self-contained (no agents.common imports) so it runs from any working
+directory. Emits one NDJSON progress event per second for SLEEP_SECONDS,
+then a final result line. Used to hold a run in the `running` state long
+enough to inject a fault (orchestrator restart) mid-run.
+
+Config via env:
+  SLEEP_SECONDS  total runtime in seconds (default 60)
+  EMIT_INTERVAL  seconds between progress events (default 1.0)
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+
+
+def _emit(obj: dict) -> None:
+    sys.stdout.write(json.dumps(obj, separators=(",", ":")) + "\n")
+    sys.stdout.flush()
+
+
+def main() -> int:
+    duration = float(os.environ.get("SLEEP_SECONDS", "60"))
+    interval = float(os.environ.get("EMIT_INTERVAL", "1.0"))
+    run_id = os.environ.get("RUN_ID", "")
+    node_id = os.environ.get("NODE_ID", "")
+
+    start = time.time()
+    elapsed = 0.0
+    tick = 0
+    _emit(
+        {
+            "type": "log",
+            "level": "info",
+            "message": f"sleep agent starting: {duration}s",
+            "data": {"run_id": run_id, "node_id": node_id, "duration": duration},
+        }
+    )
+    while elapsed < duration:
+        time.sleep(min(interval, max(0.0, duration - elapsed)))
+        tick += 1
+        elapsed = time.time() - start
+        # Emit both a heartbeat and a progress checkpoint so the run looks
+        # genuinely alive and produces a steady event stream for SSE checks.
+        _emit(
+            {"type": "heartbeat", "data": {"tick": tick, "elapsed": round(elapsed, 2)}}
+        )
+        _emit(
+            {
+                "type": "checkpoint",
+                "data": {
+                    "tick": tick,
+                    "elapsed": round(elapsed, 2),
+                    "progress": round(min(1.0, elapsed / duration), 4),
+                },
+            }
+        )
+
+    _emit(
+        {
+            "result": {"ticks": tick, "elapsed": round(time.time() - start, 2)},
+            "mentat_meta": {
+                "seconds": round(time.time() - start, 4),
+                "model": "sleep/0.1.0",
+            },
+        }
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/chaos/restart-midrun.sh
+++ b/scripts/chaos/restart-midrun.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Robustness kill-test: does an in-flight run survive an orchestrator restart?
+#
+# Runs the orchestrator natively (go run/build) against a Redis DB so we can
+# kill -TERM the process mid-run and restart it pointed at the same store.
+# A long-running `sleep` agent node holds the run in `running` state while we
+# inject the fault.
+#
+# Usage:
+#   scripts/chaos/restart-midrun.sh [redis|memory]
+#
+# Env:
+#   REDIS_URL   default redis://localhost:6379/15  (DB 15 to stay isolated)
+#   PORT        default 7071 (avoid colliding with a running stack on 7070)
+#   SLEEP_SECONDS default 60
+set -uo pipefail
+
+MODE="${1:-redis}"
+PORT="${PORT:-7071}"
+REDIS_URL="${REDIS_URL:-redis://localhost:6379/15}"
+SLEEP_SECONDS="${SLEEP_SECONDS:-60}"
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+ORCH_DIR="$REPO_ROOT/services/orchestrator-go"
+AGENT="$REPO_ROOT/agents/sleep/main.py"
+BIN="${TMPDIR:-/tmp}/mentatlab-orch-chaos"
+BASE="http://localhost:$PORT"
+
+log() { printf '\033[1;36m[chaos]\033[0m %s\n' "$*"; }
+err() { printf '\033[1;31m[chaos]\033[0m %s\n' "$*" >&2; }
+
+ORCH_PID=""
+start_orch() {
+  ORCH_RUNSTORE="$MODE" REDIS_URL="$REDIS_URL" ORCH_DRIVER=subprocess \
+    PORT="$PORT" ORCH_ALLOW_MEMORY_FALLBACK=true \
+    "$BIN" >"${TMPDIR:-/tmp}/orch-chaos.log" 2>&1 &
+  ORCH_PID=$!
+}
+wait_ready() {
+  for _ in $(seq 1 50); do
+    curl -fsS -m 2 "$BASE/healthz" >/dev/null 2>&1 && return 0
+    sleep 0.3
+  done
+  return 1
+}
+cleanup() {
+  [ -n "$ORCH_PID" ] && kill "$ORCH_PID" 2>/dev/null
+  wait "$ORCH_PID" 2>/dev/null
+}
+trap cleanup EXIT
+
+log "building orchestrator -> $BIN"
+( cd "$ORCH_DIR" && go build -o "$BIN" ./cmd/orchestrator/ ) || { err "build failed"; exit 1; }
+
+log "mode=$MODE redis_url=$REDIS_URL port=$PORT"
+start_orch
+wait_ready || { err "orchestrator did not become ready"; cat "${TMPDIR:-/tmp}/orch-chaos.log"; exit 1; }
+log "orchestrator up (pid=$ORCH_PID)"
+
+PLAN=$(cat <<JSON
+{
+  "name": "chaos-restart-midrun",
+  "auto_start": true,
+  "plan": {
+    "nodes": [
+      {
+        "id": "sleeper",
+        "type": "agent",
+        "command": ["python3", "$AGENT"],
+        "env": {"SLEEP_SECONDS": "$SLEEP_SECONDS", "EMIT_INTERVAL": "1.0"}
+      }
+    ]
+  }
+}
+JSON
+)
+
+log "creating run (sleeper holds running for ${SLEEP_SECONDS}s)"
+CREATE=$(curl -fsS -m 10 -X POST "$BASE/api/v1/runs" \
+  -H 'Content-Type: application/json' -d "$PLAN")
+echo "  create response: $CREATE"
+RUN_ID=$(printf '%s' "$CREATE" | sed -n 's/.*"run_id"[: ]*"\([^"]*\)".*/\1/p')
+[ -z "$RUN_ID" ] && RUN_ID=$(printf '%s' "$CREATE" | sed -n 's/.*"runId"[: ]*"\([^"]*\)".*/\1/p')
+[ -z "$RUN_ID" ] && { err "could not parse run_id"; exit 1; }
+log "run_id=$RUN_ID"
+
+# Wait until the run + node are actually running.
+for _ in $(seq 1 30); do
+  STATUS=$(curl -fsS -m 5 "$BASE/api/v1/runs/$RUN_ID" 2>/dev/null)
+  echo "  pre-restart: $STATUS" | head -c 400; echo
+  printf '%s' "$STATUS" | grep -q '"running"' && break
+  sleep 0.5
+done
+
+log ">>> INJECTING FAULT: kill -TERM orchestrator (pid=$ORCH_PID) mid-run"
+kill -TERM "$ORCH_PID" 2>/dev/null
+wait "$ORCH_PID" 2>/dev/null
+OLD_PID="$ORCH_PID"; ORCH_PID=""
+sleep 1
+
+log "restarting orchestrator against same store"
+start_orch
+wait_ready || { err "orchestrator did not come back"; cat "${TMPDIR:-/tmp}/orch-chaos.log"; exit 1; }
+log "orchestrator back up (pid=$ORCH_PID, was $OLD_PID)"
+
+log "querying run AFTER restart"
+HTTP_AND_BODY=$(curl -sS -m 5 -w '\n__HTTP__%{http_code}' "$BASE/api/v1/runs/$RUN_ID")
+HTTP_CODE=$(printf '%s' "$HTTP_AND_BODY" | sed -n 's/.*__HTTP__//p')
+POST_BODY=$(printf '%s' "$HTTP_AND_BODY" | sed 's/__HTTP__[0-9]*$//')
+echo "  http_code=$HTTP_CODE"
+echo "  post-restart run: $POST_BODY" | head -c 600; echo
+
+echo
+log "===== VERDICT INPUTS ====="
+echo "mode=$MODE"
+echo "post_restart_http=$HTTP_CODE  (404 => run VANISHED; 200 => state persisted)"
+echo "post_restart_status=$(printf '%s' "$POST_BODY" | sed -n 's/.*"status"[: ]*"\([^"]*\)".*/\1/p')"
+echo "(watch for: still 'running' with no progress => no resume-on-restart)"
+
+# Observe for a few seconds whether anything resumes the run.
+sleep 5
+AFTER=$(curl -fsS -m 5 "$BASE/api/v1/runs/$RUN_ID" 2>/dev/null)
+echo "post_restart_status_after_5s=$(printf '%s' "$AFTER" | sed -n 's/.*"status"[: ]*"\([^"]*\)".*/\1/p')"

--- a/scripts/chaos/sse-gap-check.mjs
+++ b/scripts/chaos/sse-gap-check.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+// Robustness kill-test (SSE half): is Last-Event-ID resumption lossless?
+//
+// Creates a run with a high-rate event burst, subscribes to SSE, forces a
+// disconnect mid-stream, reconnects with Last-Event-ID, then compares the
+// union of received event IDs against the authoritative full replay
+// (reconnect with Last-Event-ID:0). Any IDs in the full replay that were
+// never delivered across the two live connections are reported as GAPS.
+//
+// Usage:  node scripts/chaos/sse-gap-check.mjs
+// Env:    BASE (default http://localhost:7071)
+//         BURST_SECONDS (default 6)  EMIT_INTERVAL (default 0.02)
+//         DISCONNECT_AFTER (events seen before forced disconnect, default 25)
+
+const BASE = process.env.BASE || 'http://localhost:7071';
+const AGENT = new URL('../../agents/sleep/main.py', import.meta.url).pathname;
+const BURST_SECONDS = process.env.BURST_SECONDS || '6';
+const EMIT_INTERVAL = process.env.EMIT_INTERVAL || '0.02';
+const DISCONNECT_AFTER = parseInt(process.env.DISCONNECT_AFTER || '25', 10);
+
+const log = (...a) => console.log('[sse]', ...a);
+
+async function createRun() {
+  const body = {
+    name: 'chaos-sse-gap',
+    auto_start: true,
+    plan: { nodes: [{ id: 'burster', type: 'agent',
+      command: ['python3', AGENT],
+      env: { SLEEP_SECONDS: BURST_SECONDS, EMIT_INTERVAL } }] },
+  };
+  const res = await fetch(`${BASE}/api/v1/runs`, {
+    method: 'POST', headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  const j = await res.json();
+  return j.run_id || j.runId;
+}
+
+// Reads an SVG... no — reads an SSE stream. onEvent(id) per event; stops when
+// stopAfter events seen (returns 'aborted') or stream ends (returns 'ended').
+async function readSSE(runId, lastEventId, onEvent, stopAfter = Infinity) {
+  const headers = { Accept: 'text/event-stream' };
+  if (lastEventId != null) headers['Last-Event-ID'] = String(lastEventId);
+  const ctrl = new AbortController();
+  const res = await fetch(`${BASE}/api/v1/runs/${runId}/events`,
+    { headers, signal: ctrl.signal });
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = '';
+  let seen = 0;
+  let lastId = lastEventId;
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) return { reason: 'ended', lastId, seen };
+      buf += dec.decode(value, { stream: true });
+      const frames = buf.split('\n\n');
+      buf = frames.pop();
+      for (const frame of frames) {
+        let id = null, type = null;
+        for (const line of frame.split('\n')) {
+          if (line.startsWith('id:')) id = line.slice(3).trim();
+          else if (line.startsWith('event:')) type = line.slice(6).trim();
+        }
+        if (id != null) { lastId = id; onEvent(id, type); seen++; }
+        if (type === 'run_complete') return { reason: 'complete', lastId, seen };
+        if (seen >= stopAfter) { ctrl.abort(); return { reason: 'aborted', lastId, seen }; }
+      }
+    }
+  } catch (e) {
+    return { reason: 'error', error: String(e), lastId, seen };
+  }
+}
+
+async function main() {
+  log(`base=${BASE} burst=${BURST_SECONDS}s interval=${EMIT_INTERVAL}s`);
+  const runId = await createRun();
+  if (!runId) { console.error('could not create run'); process.exit(1); }
+  log(`run_id=${runId}`);
+
+  const liveIds = new Set();
+
+  // Phase 1: connect, collect until DISCONNECT_AFTER events, then drop.
+  const p1 = await readSSE(runId, null, (id) => liveIds.add(id), DISCONNECT_AFTER);
+  log(`phase1: ${p1.reason} after ${p1.seen} events, lastId=${p1.lastId}`);
+
+  // Phase 2: reconnect with Last-Event-ID, collect to completion.
+  const p2 = await readSSE(runId, p1.lastId, (id) => liveIds.add(id));
+  log(`phase2: ${p2.reason} after ${p2.seen} events, lastId=${p2.lastId}`);
+
+  // Authoritative full replay from the beginning.
+  const fullIds = new Set();
+  const pf = await readSSE(runId, '0', (id) => fullIds.add(id));
+  log(`full replay: ${pf.reason}, ${fullIds.size} distinct ids`);
+
+  // Gaps = ids present in full replay but never delivered live across p1+p2.
+  const gaps = [...fullIds].filter((id) => id !== '0' && !liveIds.has(id));
+  log('===== SSE VERDICT INPUTS =====');
+  log(`live_distinct_ids=${liveIds.size}  full_distinct_ids=${fullIds.size}`);
+  log(`gap_count=${gaps.length}`);
+  if (gaps.length) log(`sample_gaps=${gaps.slice(0, 10).join(',')}`);
+  log(gaps.length === 0
+    ? 'RESUMPTION LOSSLESS under normal disconnect (within retained window)'
+    : 'RESUMPTION DROPPED EVENTS across reconnect');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });


### PR DESCRIPTION
## Summary
Lands the **Slice 0** deliverables of the feature-robustness program (store plan_id `plan-mentatlab-feature-robustness-full-stack-vertical-hardening-cc0ae3`): a reproducible fault-injection harness plus the plan and kill-test record.

- **`agents/sleep`** — configurable long-running test agent emitting NDJSON heartbeat/checkpoint events; holds a run mid-execution so faults can be injected.
- **`scripts/chaos/restart-midrun.sh`** — `kill -TERM`s the orchestrator mid-run and reports whether the in-flight run survives (redis vs memory store).
- **`scripts/chaos/sse-gap-check.mjs`** — SSE disconnect/reconnect `Last-Event-ID` resumption gap detector.
- **`.loom/`** — plan mirror, kill-test results, index pointer.

## Kill-test verdict (2026-06-23): riskiest assumption CONFIRMED
- Restart with **redis** store → run persists but becomes an orphaned `running` zombie (no resume).
- Restart with **memory** store → run vanishes entirely (404).
- SSE was 500-broken everywhere + panicked on reconnect — both fixed in #3.

Remaining durability work (run recovery, fallback gating, etc.) is tracked as Slice 1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)