### PR TITLE
feat(orchestrator): recover interrupted runs on startup

### DIFF
--- a/services/orchestrator-go/cmd/orchestrator/main.go
+++ b/services/orchestrator-go/cmd/orchestrator/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/factories"
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/k8s"
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/mcpclient"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/runstore"
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/scheduler"
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/tracing"
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/validator"
@@ -75,6 +76,18 @@ func main() {
 		os.Exit(1)
 	}
 	defer store.Close()
+
+	// Recover runs interrupted by a previous orchestrator process. In-flight
+	// runs cannot survive a restart (the scheduler and agent subprocesses are
+	// gone), so mark them failed with a reason instead of leaving orphaned
+	// "running" zombies that never reach a terminal state.
+	recoverCtx, recoverCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	if n, rerr := runstore.RecoverInterruptedRuns(recoverCtx, store, logger.With(slog.String("component", "recovery"))); rerr != nil {
+		logger.Warn("startup run recovery scan failed", "error", rerr)
+	} else if n > 0 {
+		logger.Info("startup run recovery: marked interrupted runs failed", "count", n)
+	}
+	recoverCancel()
 
 	// Initialize driver and scheduler
 	emitter := driver.NewRunStoreEmitter(store)

--- a/services/orchestrator-go/internal/runstore/recovery.go
+++ b/services/orchestrator-go/internal/runstore/recovery.go
@@ -1,0 +1,117 @@
+package runstore
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/pkg/types"
+)
+
+// RunRecoveryReason is the reason recorded on runs/nodes failed by startup
+// recovery.
+const RunRecoveryReason = "orchestrator_restart"
+
+// RecoverInterruptedRuns reconciles runs left in a non-terminal state by a
+// previous orchestrator process. The in-process scheduler and agent
+// subprocesses do not survive a restart, so such runs cannot continue; left
+// alone they remain "running" forever (an orphaned zombie). This marks each
+// interrupted run — and any of its still-in-flight nodes — failed with a
+// reason and emits a terminal "status" event so live subscribers learn the
+// outcome instead of hanging on a run that will never progress.
+//
+// It assumes a single active orchestrator, which is the default deployment.
+// With multiple replicas sharing one store this would incorrectly fail runs
+// owned by a peer, so gate it before enabling multi-replica execution.
+//
+// Returns the number of runs recovered. A nil/empty store (e.g. a fresh
+// in-memory store) simply yields zero.
+func RecoverInterruptedRuns(ctx context.Context, store RunStore, logger *slog.Logger) (int, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	ids, err := store.ListRuns(ctx)
+	if err != nil {
+		return 0, fmt.Errorf("list runs: %w", err)
+	}
+
+	recovered := 0
+	for _, id := range ids {
+		run, err := store.GetRun(ctx, id)
+		if err != nil {
+			logger.Warn("run recovery: failed to load run", "run_id", id, "error", err)
+			continue
+		}
+		if run == nil || isTerminalRunStatus(run.Status) {
+			continue
+		}
+
+		// Fail any node still in flight so node-level views stay consistent
+		// with the run's terminal state.
+		if run.Plan != nil {
+			for i := range run.Plan.Nodes {
+				nodeID := run.Plan.Nodes[i].ID
+				ns, nerr := store.GetNodeState(ctx, id, nodeID)
+				if nerr != nil || ns == nil || isTerminalNodeStatus(ns.Status) {
+					continue
+				}
+				ns.Status = types.NodeStatusFailed
+				ns.Error = "orchestrator restarted before node completion"
+				finished := time.Now().UTC()
+				ns.FinishedAt = &finished
+				if uerr := store.UpdateNodeState(ctx, id, nodeID, ns); uerr != nil {
+					logger.Warn("run recovery: failed to fail node",
+						"run_id", id, "node_id", nodeID, "error", uerr)
+				}
+			}
+		}
+
+		finishedAt := time.Now().UTC().Format(time.RFC3339)
+		if err := store.UpdateRunStatus(ctx, id, types.RunStatusFailed, nil, &finishedAt); err != nil {
+			logger.Warn("run recovery: failed to mark run failed", "run_id", id, "error", err)
+			continue
+		}
+
+		// Mirror the scheduler's terminal "status" event shape so SSE clients
+		// observe the failure and its reason.
+		if _, err := store.AppendEvent(ctx, id, &types.EventInput{
+			Type: types.EventType("status"),
+			Data: map[string]interface{}{
+				"runId":  id,
+				"status": string(types.RunStatusFailed),
+				"reason": RunRecoveryReason,
+			},
+		}); err != nil {
+			logger.Warn("run recovery: failed to emit terminal event", "run_id", id, "error", err)
+		}
+
+		recovered++
+		logger.Warn("run recovery: marked interrupted run failed",
+			"run_id", id, "previous_status", string(run.Status), "reason", RunRecoveryReason)
+	}
+
+	if recovered > 0 {
+		logger.Warn("run recovery complete", "recovered_runs", recovered)
+	}
+	return recovered, nil
+}
+
+func isTerminalRunStatus(s types.RunStatus) bool {
+	switch s {
+	case types.RunStatusSucceeded, types.RunStatusFailed, types.RunStatusCancelled:
+		return true
+	default:
+		return false
+	}
+}
+
+func isTerminalNodeStatus(s types.NodeStatus) bool {
+	switch s {
+	case types.NodeStatusSucceeded, types.NodeStatusFailed, types.NodeStatusSkipped:
+		return true
+	default:
+		return false
+	}
+}

--- a/services/orchestrator-go/internal/runstore/recovery_test.go
+++ b/services/orchestrator-go/internal/runstore/recovery_test.go
@@ -1,0 +1,119 @@
+package runstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/pkg/types"
+)
+
+// helper: create a run and drive it into the running state.
+func mkRun(t *testing.T, store RunStore, status types.RunStatus) string {
+	t.Helper()
+	ctx := context.Background()
+	id, err := store.CreateRun(ctx, "r", &types.Plan{Nodes: []types.NodeSpec{{ID: "n1"}}}, "")
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	if status != types.RunStatusQueued {
+		if err := store.UpdateRunStatus(ctx, id, status, nil, nil); err != nil {
+			t.Fatalf("UpdateRunStatus: %v", err)
+		}
+	}
+	return id
+}
+
+func TestRecoverInterruptedRuns_FailsRunningRuns(t *testing.T) {
+	store, _ := newTestRedisStore(t)
+	ctx := context.Background()
+
+	running := mkRun(t, store, types.RunStatusRunning)
+	queued := mkRun(t, store, types.RunStatusQueued)
+	// mark a node running so we can assert it gets failed too
+	if err := store.UpdateNodeState(ctx, running, "n1", &types.NodeState{
+		NodeID: "n1", Status: types.NodeStatusRunning,
+	}); err != nil {
+		t.Fatalf("UpdateNodeState: %v", err)
+	}
+
+	n, err := RecoverInterruptedRuns(ctx, store, nil)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedRuns: %v", err)
+	}
+	if n != 2 {
+		t.Fatalf("recovered = %d, want 2 (running + queued)", n)
+	}
+
+	for _, id := range []string{running, queued} {
+		run, err := store.GetRun(ctx, id)
+		if err != nil {
+			t.Fatalf("GetRun(%s): %v", id, err)
+		}
+		if run.Status != types.RunStatusFailed {
+			t.Errorf("run %s status = %q, want failed", id, run.Status)
+		}
+		if run.FinishedAt == nil {
+			t.Errorf("run %s FinishedAt not set", id)
+		}
+	}
+
+	ns, err := store.GetNodeState(ctx, running, "n1")
+	if err != nil {
+		t.Fatalf("GetNodeState: %v", err)
+	}
+	if ns.Status != types.NodeStatusFailed {
+		t.Errorf("node status = %q, want failed", ns.Status)
+	}
+
+	// A terminal status event must be observable for the recovered run.
+	events, err := store.GetEventsSince(ctx, running, "")
+	if err != nil {
+		t.Fatalf("GetEventsSince: %v", err)
+	}
+	found := false
+	for _, e := range events {
+		if e.Type == types.EventType("status") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected a terminal status event for the recovered run")
+	}
+}
+
+func TestRecoverInterruptedRuns_LeavesTerminalRunsAlone(t *testing.T) {
+	store, _ := newTestRedisStore(t)
+	ctx := context.Background()
+
+	done := mkRun(t, store, types.RunStatusSucceeded)
+	cancelled := mkRun(t, store, types.RunStatusCancelled)
+
+	n, err := RecoverInterruptedRuns(ctx, store, nil)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedRuns: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("recovered = %d, want 0 (no non-terminal runs)", n)
+	}
+
+	d, _ := store.GetRun(ctx, done)
+	if d.Status != types.RunStatusSucceeded {
+		t.Errorf("succeeded run mutated to %q", d.Status)
+	}
+	c, _ := store.GetRun(ctx, cancelled)
+	if c.Status != types.RunStatusCancelled {
+		t.Errorf("cancelled run mutated to %q", c.Status)
+	}
+}
+
+// Memory store with no runs must be a clean no-op.
+func TestRecoverInterruptedRuns_EmptyMemoryStore(t *testing.T) {
+	store := NewMemoryStore(nil)
+	n, err := RecoverInterruptedRuns(context.Background(), store, nil)
+	if err != nil {
+		t.Fatalf("RecoverInterruptedRuns: %v", err)
+	}
+	if n != 0 {
+		t.Fatalf("recovered = %d, want 0", n)
+	}
+}


### PR DESCRIPTION
## Summary
Kills the orphaned-`running`-zombie behavior the robustness kill-test confirmed (Slice 1 of `plan-mentatlab-feature-robustness-...`).

Before: a run in flight when the orchestrator restarted became a zombie — Redis store kept it `running` forever (scheduler + agent subprocesses are gone, nothing resumes it); memory store lost it entirely.

After: on startup, `RecoverInterruptedRuns` scans the runstore for runs left in a non-terminal state (`running`/`queued`), fails their in-flight nodes, marks the run `failed` with reason `orchestrator_restart`, and emits a terminal `status` event so live SSE subscribers learn the outcome instead of hanging. Wired into `main()` right after the store is created.

Single active orchestrator is assumed (the default deployment) and documented; multi-replica execution must be gated before enabling.

## Tests
- running + queued runs → failed (incl. their nodes), terminal event emitted
- succeeded/cancelled runs untouched
- empty store is a no-op
- full `orchestrator-go` suite green

## Verified live
`scripts/chaos/restart-midrun.sh redis`: post-restart run is now `failed` with `finished_at` set (previously a zombie `running`).

## Follow-ups (remaining Slice 1)
memory-fallback fail-fast gating + unified Redis-URL db-index parsing; Redis write retry/buffer on breaker-open; K8s watch `resourceVersion` resume; heartbeat-timeout bounded ctx; SIGTERM scheduler drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)