### PR TITLE
fix(orchestrator): no silent store fallback + consistent Redis URL parsing

### DIFF
--- a/services/orchestrator-go/cmd/orchestrator/main.go
+++ b/services/orchestrator-go/cmd/orchestrator/main.go
@@ -7,7 +7,6 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
-	"strings"
 	"syscall"
 	"time"
 
@@ -167,10 +166,10 @@ func main() {
 	// Initialize API key store (requires Redis)
 	var apiKeyStore *auth.APIKeyStore
 	if cfg.RunStoreType == "redis" {
-		redisAddr := strings.TrimPrefix(cfg.RedisURL, "redis://")
-		apiKeyRedis := redisClient(redisAddr, cfg.RedisPassword, cfg.RedisDB)
-		if apiKeyRedis != nil {
-			apiKeyStore = auth.NewAPIKeyStore(apiKeyRedis)
+		if opts, oerr := factories.ResolveRedisOptions(cfg); oerr != nil {
+			logger.Error("failed to resolve redis options for API key store", "error", oerr)
+		} else {
+			apiKeyStore = auth.NewAPIKeyStore(redis.NewClient(opts))
 			logger.Info("API key store initialized (Redis)")
 		}
 	}
@@ -294,13 +293,4 @@ func main() {
 	}
 
 	logger.Info("server stopped")
-}
-
-// redisClient creates a Redis client for the given address.
-func redisClient(addr, password string, db int) *redis.Client {
-	return redis.NewClient(&redis.Options{
-		Addr:     addr,
-		Password: password,
-		DB:       db,
-	})
 }

--- a/services/orchestrator-go/internal/factories/factories.go
+++ b/services/orchestrator-go/internal/factories/factories.go
@@ -2,8 +2,8 @@ package factories
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
-	"strings"
 
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/config"
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/driver"
@@ -14,6 +14,7 @@ import (
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/runstore"
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/scheduler"
 	"github.com/flexinfer/mentatlab/services/orchestrator-go/pkg/types"
+	"github.com/redis/go-redis/v9"
 )
 
 // CreateRunStore initializes a RunStore based on the provided configuration.
@@ -82,15 +83,19 @@ func CreateDriver(cfg *config.Config, emitter driver.EventEmitter, logger *slog.
 // CreateAgentRegistry initializes an AgentRegistry based on the provided configuration.
 func CreateAgentRegistry(cfg *config.Config, logger *slog.Logger) (registry.AgentRegistry, error) {
 	if cfg.RunStoreType == "redis" {
-		redisAddr := strings.TrimPrefix(cfg.RedisURL, "redis://")
-		registryCfg := &registry.RedisConfig{
-			Addr:     redisAddr,
-			Password: cfg.RedisPassword,
-			DB:       cfg.RedisDB,
-		}
-		redisRegistry, err := registry.NewRedisRegistry(registryCfg)
+		opts, err := ResolveRedisOptions(cfg)
 		if err != nil {
-			logger.Warn("failed to create Redis agent registry, using memory", "error", err)
+			return nil, err
+		}
+		redisRegistry, err := registry.NewRedisRegistry(&registry.RedisConfig{
+			Addr:     opts.Addr,
+			Password: opts.Password,
+			DB:       opts.DB,
+		})
+		if err != nil {
+			if ferr := handleStoreFallback(cfg, logger, "agent registry", err); ferr != nil {
+				return nil, ferr
+			}
 			return registry.NewMemoryRegistryWithDefaults(), nil
 		}
 		if err := redisRegistry.SeedDefaultAgents(context.Background()); err != nil {
@@ -107,10 +112,15 @@ func CreateAgentRegistry(cfg *config.Config, logger *slog.Logger) (registry.Agen
 // CreateFlowStore initializes a FlowStore based on the provided configuration.
 func CreateFlowStore(cfg *config.Config, logger *slog.Logger) (flowstore.FlowStore, error) {
 	if cfg.RunStoreType == "redis" {
-		redisAddr := strings.TrimPrefix(cfg.RedisURL, "redis://")
-		redisFlows, err := flowstore.NewRedisStore(redisAddr)
+		opts, err := ResolveRedisOptions(cfg)
 		if err != nil {
-			logger.Warn("failed to create Redis flow store, using memory", "error", err)
+			return nil, err
+		}
+		redisFlows, err := flowstore.NewRedisStoreFromOptions(opts)
+		if err != nil {
+			if ferr := handleStoreFallback(cfg, logger, "flow store", err); ferr != nil {
+				return nil, ferr
+			}
 			return flowstore.NewMemoryStore(), nil
 		}
 		logger.Info("using Redis flow store")
@@ -118,6 +128,44 @@ func CreateFlowStore(cfg *config.Config, logger *slog.Logger) (flowstore.FlowSto
 	}
 	logger.Info("using in-memory flow store")
 	return flowstore.NewMemoryStore(), nil
+}
+
+// ResolveRedisOptions builds redis.Options from configuration, parsing the
+// redis:// URL (so a DB index like redis://host:6379/2 is honored) and
+// overlaying explicit REDIS_PASSWORD / REDIS_DB when set. Centralizes URL
+// parsing so every Redis client in the orchestrator behaves consistently.
+func ResolveRedisOptions(cfg *config.Config) (*redis.Options, error) {
+	opts := &redis.Options{Addr: cfg.RedisURL, Password: cfg.RedisPassword, DB: cfg.RedisDB}
+	if cfg.RedisURL != "" {
+		parsed, err := redis.ParseURL(cfg.RedisURL)
+		if err != nil {
+			return nil, fmt.Errorf("parse redis url %q: %w", cfg.RedisURL, err)
+		}
+		opts.Addr = parsed.Addr
+		if parsed.Password != "" && cfg.RedisPassword == "" {
+			opts.Password = parsed.Password
+		}
+		if parsed.DB != 0 && cfg.RedisDB == 0 {
+			opts.DB = parsed.DB
+		}
+	}
+	return opts, nil
+}
+
+// handleStoreFallback decides whether a Redis store creation failure hard-fails
+// (the default) or falls back to memory (only when AllowMemoryFallback is set).
+// Any fallback is loud — WARN + metric — so it is never silent.
+func handleStoreFallback(cfg *config.Config, logger *slog.Logger, name string, cause error) error {
+	if cause == nil {
+		return nil
+	}
+	if !cfg.AllowMemoryFallback {
+		return fmt.Errorf("redis %s unavailable and ORCH_ALLOW_MEMORY_FALLBACK is not set: %w", name, cause)
+	}
+	metrics.RunStoreFallbackTotal.Inc()
+	logger.Warn("Redis "+name+" unavailable, falling back to in-memory store (ORCH_ALLOW_MEMORY_FALLBACK=true) — data will NOT persist across restarts",
+		"error", cause)
+	return nil
 }
 
 // CreateCommandResolver returns a function that resolves node specs to command lines.

--- a/services/orchestrator-go/internal/factories/factories_test.go
+++ b/services/orchestrator-go/internal/factories/factories_test.go
@@ -1,0 +1,75 @@
+package factories
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/config"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestResolveRedisOptions_ParsesDBIndex(t *testing.T) {
+	opts, err := ResolveRedisOptions(&config.Config{RedisURL: "redis://localhost:6379/7"})
+	if err != nil {
+		t.Fatalf("ResolveRedisOptions: %v", err)
+	}
+	if opts.Addr != "localhost:6379" {
+		t.Errorf("Addr = %q, want localhost:6379", opts.Addr)
+	}
+	if opts.DB != 7 {
+		t.Errorf("DB = %d, want 7 (db index must be parsed from URL, not treated as part of the host)", opts.DB)
+	}
+}
+
+func TestResolveRedisOptions_ExplicitDBOverridesZeroURLDB(t *testing.T) {
+	opts, err := ResolveRedisOptions(&config.Config{RedisURL: "redis://localhost:6379", RedisDB: 3})
+	if err != nil {
+		t.Fatalf("ResolveRedisOptions: %v", err)
+	}
+	if opts.DB != 3 {
+		t.Errorf("DB = %d, want 3 (explicit REDIS_DB)", opts.DB)
+	}
+}
+
+func TestResolveRedisOptions_BadURL(t *testing.T) {
+	if _, err := ResolveRedisOptions(&config.Config{RedisURL: "://not a url"}); err == nil {
+		t.Fatal("expected error for malformed redis url")
+	}
+}
+
+// With an unreachable Redis and fallback disabled (the default), store
+// creation must hard-fail rather than silently degrade to memory.
+func TestCreateStores_FailFastWhenFallbackDisabled(t *testing.T) {
+	cfg := &config.Config{
+		RunStoreType:        "redis",
+		RedisURL:            "redis://127.0.0.1:1", // connection refused
+		AllowMemoryFallback: false,
+	}
+	if _, err := CreateAgentRegistry(cfg, discardLogger()); err == nil {
+		t.Error("CreateAgentRegistry: expected error (fallback disabled), got nil")
+	}
+	if _, err := CreateFlowStore(cfg, discardLogger()); err == nil {
+		t.Error("CreateFlowStore: expected error (fallback disabled), got nil")
+	}
+}
+
+// With fallback explicitly enabled, store creation degrades to memory.
+func TestCreateStores_FallbackWhenEnabled(t *testing.T) {
+	cfg := &config.Config{
+		RunStoreType:        "redis",
+		RedisURL:            "redis://127.0.0.1:1",
+		AllowMemoryFallback: true,
+	}
+	reg, err := CreateAgentRegistry(cfg, discardLogger())
+	if err != nil || reg == nil {
+		t.Errorf("CreateAgentRegistry: want memory fallback, got reg=%v err=%v", reg, err)
+	}
+	fs, err := CreateFlowStore(cfg, discardLogger())
+	if err != nil || fs == nil {
+		t.Errorf("CreateFlowStore: want memory fallback, got fs=%v err=%v", fs, err)
+	}
+}

--- a/services/orchestrator-go/internal/flowstore/redis.go
+++ b/services/orchestrator-go/internal/flowstore/redis.go
@@ -37,6 +37,22 @@ func NewRedisStore(addr string) (*RedisStore, error) {
 	return &RedisStore{client: client}, nil
 }
 
+// NewRedisStoreFromOptions creates a store from redis.Options (e.g. parsed
+// from a redis:// URL via redis.ParseURL), honoring DB index and password.
+// It verifies the connection before returning.
+func NewRedisStoreFromOptions(opts *redis.Options) (*RedisStore, error) {
+	client := redis.NewClient(opts)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	if err := client.Ping(ctx).Err(); err != nil {
+		return nil, fmt.Errorf("redis connection failed: %w", err)
+	}
+
+	return &RedisStore{client: client}, nil
+}
+
 // NewRedisStoreWithClient creates a store using an existing Redis client.
 func NewRedisStoreWithClient(client *redis.Client) *RedisStore {
 	return &RedisStore{client: client}


### PR DESCRIPTION
## Summary
Two coupled persistence-robustness fixes (Slice 1) surfaced by the kill-test — both are forms of *silent* data loss.

### 1. Silent memory fallback (registry + flow store)
The agent registry and flow store fell back to an in-memory store whenever Redis failed, **regardless of `ORCH_ALLOW_MEMORY_FALLBACK`**. A transient Redis outage silently became non-persistent state (lost on restart) with only a quiet warn. They now route through `handleStoreFallback`: **hard-fail by default**, fall back only when `ORCH_ALLOW_MEMORY_FALLBACK=true`, and **loudly** (WARN + metric). This matches the runstore's existing behavior, so all three stores are now consistent.

### 2. Inconsistent Redis URL parsing
The registry, flow store, and API-key store derived the address via `strings.TrimPrefix(url, "redis://")`, which mangles a DB-index URL: `redis://host:6379/2` → addr `host:6379/2` → `unknown port` → silent memory fallback (observed live in the kill-test). All three now use a shared `ResolveRedisOptions` helper backed by `redis.ParseURL` (same as the runstore), honoring DB index + password.

## Changes
- `factories.ResolveRedisOptions` (shared) + `factories.handleStoreFallback`
- `flowstore.NewRedisStoreFromOptions` (URL/options-aware, pings)
- API-key store in `main` uses the shared resolver; removed the redundant `redisClient` helper

## Tests
- `ResolveRedisOptions` parses DB index, applies explicit `REDIS_DB`, errors on bad URL
- unreachable Redis → registry+flowstore hard-fail when fallback disabled, degrade to memory when enabled
- full `orchestrator-go` suite green

## Follow-ups (remaining Slice 1)
Redis write retry/buffer on breaker-open; K8s watch `resourceVersion` resume; heartbeat-timeout bounded ctx; SIGTERM scheduler drain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)