### PR TITLE
feat(orchestrator): drain in-flight runs on graceful shutdown

### DIFF
--- a/services/orchestrator-go/cmd/orchestrator/main.go
+++ b/services/orchestrator-go/cmd/orchestrator/main.go
@@ -281,6 +281,15 @@ func main() {
 	ctx, cancel := context.WithTimeout(context.Background(), cfg.ShutdownGrace)
 	defer cancel()
 
+	// Stop accepting new runs and drain in-flight runs (bounded by the grace
+	// period). Anything still running when the grace expires is reconciled by
+	// startup recovery on the next boot.
+	if err := sched.Shutdown(ctx); err != nil {
+		logger.Warn("scheduler drain did not complete within grace; remaining runs will be recovered on next start", "error", err)
+	} else {
+		logger.Info("scheduler drained")
+	}
+
 	// Shutdown tracer
 	if tracingProvider != nil {
 		if err := tracingProvider.Shutdown(ctx); err != nil {

--- a/services/orchestrator-go/internal/scheduler/drain_test.go
+++ b/services/orchestrator-go/internal/scheduler/drain_test.go
@@ -1,0 +1,58 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/pkg/types"
+)
+
+// Shutdown on an idle scheduler returns immediately and then rejects new runs.
+func TestShutdown_IdleThenRejectsNewRuns(t *testing.T) {
+	s, _ := newTestScheduler(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := s.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown on idle scheduler: %v", err)
+	}
+
+	err := s.EnqueueRun(context.Background(), "r1", "r1", &types.Plan{
+		Nodes: []types.NodeSpec{{ID: "n1"}},
+	})
+	if !errors.Is(err, ErrSchedulerDraining) {
+		t.Fatalf("EnqueueRun after Shutdown = %v, want ErrSchedulerDraining", err)
+	}
+	if n := s.ActiveRuns(); n != 0 {
+		t.Fatalf("ActiveRuns = %d, want 0", n)
+	}
+}
+
+// Shutdown waits for in-flight runs and honors the context deadline: an
+// enqueued run that never finishes makes Shutdown return the ctx error rather
+// than abandoning it silently.
+func TestShutdown_WaitsForInFlightRunsUntilDeadline(t *testing.T) {
+	s, _ := newTestScheduler(t)
+
+	if err := s.EnqueueRun(context.Background(), "r1", "r1", &types.Plan{
+		Nodes: []types.NodeSpec{{ID: "n1"}},
+	}); err != nil {
+		t.Fatalf("EnqueueRun: %v", err)
+	}
+	if n := s.ActiveRuns(); n != 1 {
+		t.Fatalf("ActiveRuns = %d, want 1", n)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 150*time.Millisecond)
+	defer cancel()
+	start := time.Now()
+	err := s.Shutdown(ctx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Shutdown = %v, want context.DeadlineExceeded (must wait for the in-flight run)", err)
+	}
+	if elapsed := time.Since(start); elapsed < 100*time.Millisecond {
+		t.Fatalf("Shutdown returned after %v; expected it to block until the deadline", elapsed)
+	}
+}

--- a/services/orchestrator-go/internal/scheduler/scheduler.go
+++ b/services/orchestrator-go/internal/scheduler/scheduler.go
@@ -3,6 +3,7 @@ package scheduler
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"sync"
@@ -20,6 +21,10 @@ import (
 )
 
 var tracer = otel.Tracer("mentatlab/scheduler")
+
+// ErrSchedulerDraining is returned by EnqueueRun when the scheduler is shutting
+// down and no longer accepting new runs.
+var ErrSchedulerDraining = errors.New("scheduler is draining; not accepting new runs")
 
 // CommandResolver resolves a NodeSpec to a command line to execute.
 type CommandResolver func(node *types.NodeSpec) []string
@@ -51,6 +56,7 @@ type Scheduler struct {
 	resolveCmd         CommandResolver
 	runs               map[string]*runContext
 	runsMu             sync.Mutex
+	draining           bool          // set during graceful shutdown; rejects new runs
 	sem                chan struct{} // Parallelism limiter
 	defaultMaxRetries  int
 	defaultBackoffSecs int
@@ -201,6 +207,10 @@ func (s *Scheduler) EnqueueRun(ctx context.Context, runID, name string, plan *ty
 	s.runsMu.Lock()
 	defer s.runsMu.Unlock()
 
+	if s.draining {
+		return ErrSchedulerDraining
+	}
+
 	if _, exists := s.runs[runID]; exists {
 		return nil // Already enqueued
 	}
@@ -329,6 +339,41 @@ func (s *Scheduler) StartRun(ctx context.Context, runID string) error {
 		s.runLoop(runCtx, rctx)
 	}()
 
+	return nil
+}
+
+// ActiveRuns returns the number of runs currently tracked by the scheduler.
+func (s *Scheduler) ActiveRuns() int {
+	s.runsMu.Lock()
+	defer s.runsMu.Unlock()
+	return len(s.runs)
+}
+
+// Shutdown stops accepting new runs and waits for in-flight runs to finish,
+// bounded by ctx. It is used for graceful shutdown so a rolling deploy does
+// not abandon active runs. Runs still in flight when ctx expires are left for
+// startup recovery to reconcile on the next boot (see runstore.RecoverInterruptedRuns).
+func (s *Scheduler) Shutdown(ctx context.Context) error {
+	// Stop accepting new runs and snapshot the in-flight set's done channels.
+	s.runsMu.Lock()
+	s.draining = true
+	dones := make([]chan struct{}, 0, len(s.runs))
+	for _, rctx := range s.runs {
+		dones = append(dones, rctx.done)
+	}
+	s.runsMu.Unlock()
+
+	if len(dones) > 0 {
+		s.logger.Info("draining in-flight runs before shutdown", slog.Int("active_runs", len(dones)))
+	}
+
+	for _, done := range dones {
+		select {
+		case <-done:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Summary
Final Slice 1 durability item. On SIGINT/SIGTERM the orchestrator shut down its HTTP server but never waited for in-flight runs — a rolling deploy abandoned active runs mid-execution (left for startup recovery to fail).

`Scheduler.Shutdown(ctx)` now:
- sets a `draining` flag so `EnqueueRun` rejects new work (`ErrSchedulerDraining`)
- waits for in-flight runs to finish via their `done` channels, bounded by the existing `ShutdownGrace`

Runs still active when the grace expires are reconciled by startup recovery (PR #5) on the next boot. Wired into `main()` before the HTTP server shutdown. Adds `Scheduler.ActiveRuns()` for observability/tests.

## Tests
- idle `Shutdown` returns immediately, then `EnqueueRun` → `ErrSchedulerDraining`
- an in-flight run makes `Shutdown` block until the context deadline (`-race`)
- full `orchestrator-go` suite green

## Slice 1 status
With this, the durability slice's headline criteria are complete: SSE works/lossless (#3), runs reach a deterministic terminal state on restart (#5), no silent store fallback (#6), graceful drain on deploy (this). Remaining items (Redis write buffer on breaker-open; K8s-mode watch `resourceVersion` + heartbeat ctx) are lower-severity follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)