### PR TITLE
fix(orchestrator): make gate timeout fail-safe (reject by default)

### DIFF
--- a/services/orchestrator-go/internal/scheduler/gate.go
+++ b/services/orchestrator-go/internal/scheduler/gate.go
@@ -65,10 +65,14 @@ func (s *Scheduler) executeGate(ctx context.Context, rctx *runContext, nodeID st
 	case decision = <-ch:
 		// Received approve or reject
 	case <-timeoutCh:
-		if gate.AutoReject {
-			decision = "reject"
-		} else {
+		// Fail-safe: a timed-out gate rejects unless explicitly configured to
+		// auto-approve. (Previously it auto-approved whenever AutoReject was
+		// false, contradicting the documented behavior and unsafe for approval
+		// gates — a missed approval would silently let the run proceed.)
+		if gate.AutoApprove {
 			decision = "approve"
+		} else {
+			decision = "reject"
 		}
 		s.logger.Info("gate timed out",
 			slog.String("run_id", rctx.runID),

--- a/services/orchestrator-go/internal/scheduler/gate_timeout_test.go
+++ b/services/orchestrator-go/internal/scheduler/gate_timeout_test.go
@@ -1,0 +1,86 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/runstore"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/pkg/types"
+)
+
+func startGateRun(t *testing.T, gate *types.GateConfig) (*Scheduler, *runstore.MemoryStore, string) {
+	t.Helper()
+	store := runstore.NewMemoryStore(nil)
+	s := New(store, &mockDriver{}, testCommandResolver, nil, slog.Default())
+	plan := &types.Plan{Nodes: []types.NodeSpec{{ID: "gate1", Type: types.NodeTypeGate, Gate: gate}}}
+	ctx := context.Background()
+	runID, _ := store.CreateRun(ctx, "gate", plan, "")
+	if err := s.EnqueueRun(ctx, runID, "gate", plan); err != nil {
+		t.Fatalf("EnqueueRun: %v", err)
+	}
+	if err := s.StartRun(ctx, runID); err != nil {
+		t.Fatalf("StartRun: %v", err)
+	}
+	return s, store, runID
+}
+
+// A timed-out gate with no explicit auto-approve must REJECT (fail-safe).
+// This is the regression test for the previous behavior, which auto-approved
+// whenever AutoReject was false.
+func TestGateTimeout_DefaultRejects(t *testing.T) {
+	_, store, runID := startGateRun(t, &types.GateConfig{
+		Description: "no explicit timeout policy",
+		Timeout:     100 * time.Millisecond,
+		// neither AutoReject nor AutoApprove set
+	})
+
+	time.Sleep(400 * time.Millisecond)
+
+	state, _ := store.GetNodeState(context.Background(), runID, "gate1")
+	if state.Status != types.NodeStatusFailed {
+		t.Errorf("default timeout must be fail-safe (reject); got node status %s", state.Status)
+	}
+}
+
+// A timed-out gate explicitly configured to auto-approve must SUCCEED.
+func TestGateTimeout_AutoApprove(t *testing.T) {
+	_, store, runID := startGateRun(t, &types.GateConfig{
+		Description: "auto-approve on timeout",
+		Timeout:     100 * time.Millisecond,
+		AutoApprove: true,
+	})
+
+	time.Sleep(400 * time.Millisecond)
+
+	state, _ := store.GetNodeState(context.Background(), runID, "gate1")
+	if state.Status != types.NodeStatusSucceeded {
+		t.Errorf("auto-approve timeout should succeed; got node status %s", state.Status)
+	}
+}
+
+// Once a gate has resolved, a second decision is rejected (no double-approve).
+func TestGateApproveTwice_SecondErrors(t *testing.T) {
+	s, _, runID := startGateRun(t, &types.GateConfig{Description: "approve once"})
+
+	time.Sleep(100 * time.Millisecond)
+	if err := s.ApproveGate(runID, "gate1"); err != nil {
+		t.Fatalf("first approve: %v", err)
+	}
+	time.Sleep(150 * time.Millisecond) // let the gate resolve + deregister
+
+	if err := s.ApproveGate(runID, "gate1"); err == nil {
+		t.Error("second approve on an already-resolved gate should error")
+	}
+}
+
+// Signaling a valid run but a node that is not a waiting gate must error.
+func TestGateSignal_UnknownNode(t *testing.T) {
+	s, _, runID := startGateRun(t, &types.GateConfig{Description: "real gate"})
+
+	time.Sleep(100 * time.Millisecond)
+	if err := s.ApproveGate(runID, "does-not-exist"); err == nil {
+		t.Error("approving an unknown node should error")
+	}
+}

--- a/services/orchestrator-go/pkg/types/control.go
+++ b/services/orchestrator-go/pkg/types/control.go
@@ -71,13 +71,18 @@ type GateConfig struct {
 	// Description is a human-readable explanation of what approval is needed.
 	Description string `json:"description,omitempty"`
 
-	// Timeout is the maximum time to wait for approval before auto-rejecting.
-	// Zero means wait indefinitely.
+	// Timeout is the maximum time to wait for approval before the gate
+	// resolves on its own. Zero means wait indefinitely.
 	Timeout time.Duration `json:"timeout,omitempty"`
 
-	// AutoReject determines whether the gate auto-rejects (true) or auto-approves (false)
-	// when the timeout expires. Only relevant when Timeout > 0.
+	// AutoReject is deprecated and no longer changes behavior: a timed-out gate
+	// rejects by default (fail-safe). Retained for backward compatibility with
+	// stored plans. Use AutoApprove to opt into approving on timeout instead.
 	AutoReject bool `json:"auto_reject,omitempty"`
+
+	// AutoApprove makes the gate approve (rather than the fail-safe reject)
+	// when the timeout expires. Only relevant when Timeout > 0.
+	AutoApprove bool `json:"auto_approve,omitempty"`
 }
 
 // NodeType constants for control flow nodes.


### PR DESCRIPTION
## Summary
Slice 4 (gate/approval hardening). A gate node's timeout did the **opposite of its documented behavior**: the doc said it "auto-rejects", but the code auto-**approved** whenever `AutoReject` was false (the default). For an approval gate that's a real safety hole — a missed or delayed approval silently lets the run proceed.

Timeout is now **fail-safe**: a timed-out gate **rejects** unless explicitly configured to auto-approve via the new `GateConfig.AutoApprove`. `AutoReject` is kept for backward compatibility but no longer changes behavior (reject is the default either way). This matches the frontend, which already defaults `auto_reject=true`.

## Tests (gates were thinly covered)
- **default timeout → reject** (regression test for the old auto-approve)
- explicit `AutoApprove` → approve
- a resolved gate rejects a second decision (no double-approve)
- signaling an unknown node errors
- existing approve / reject / auto-reject tests still pass

## Restart behavior (acceptance note)
Full *gate-survives-restart with resume* requires run-resumption infrastructure, which is a stated non-goal of this plan ("checkpoint-resume build-out beyond what existing journeys use"). Today a gate-waiting run is handled deterministically by startup recovery (PR #5): it's marked failed with a reason rather than left as a stuck/unapprovable zombie. Tracked as a follow-up if we later invest in run resumption.

## Audit / scope
Approve/reject are POST endpoints already covered by the audit middleware. Per-endpoint scope enforcement is Slice 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)