### PR TITLE
test(orchestrator): SSE + runstore parity tests, fix memory replay, CI coverage floor

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -165,8 +165,25 @@ test-go:
     - *apk_add_git
     - *clone_repo
   script:
-    - (cd services/gateway-go && go mod download && go test -v -coverprofile=cover.out ./... && go tool cover -func=cover.out)
-    - (cd services/orchestrator-go && go mod download && go test -v -coverprofile=cover.out ./... && go tool cover -func=cover.out)
+    # Run tests, report coverage, and enforce a floor so coverage cannot
+    # silently regress. Floors are set just below current coverage; ratchet up
+    # as coverage improves.
+    - |
+      set -e
+      check_cov() { # $1=dir $2=floor
+        cd "$1"
+        go mod download
+        go test -v -coverprofile=cover.out ./...
+        go tool cover -func=cover.out | tee cover.txt
+        total=$(grep -E '^total:' cover.txt | grep -oE '[0-9]+\.[0-9]+' | head -1)
+        awk -v t="$total" -v min="$2" 'BEGIN {
+          if (t+0 < min+0) { printf("FAIL: %s coverage %.1f%% below floor %.1f%%\n", "'"$1"'", t, min); exit 1 }
+          printf("OK: %s coverage %.1f%% >= floor %.1f%%\n", "'"$1"'", t, min)
+        }'
+        cd - >/dev/null
+      }
+      check_cov services/gateway-go 60.0
+      check_cov services/orchestrator-go 55.0
   coverage: '/total:\s+\(statements\)\s+(\d+\.\d+)%/'
   rules:
     - if: '$CI_COMMIT_BRANCH == "main"'

--- a/services/orchestrator-go/internal/api/sse_test.go
+++ b/services/orchestrator-go/internal/api/sse_test.go
@@ -1,0 +1,89 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/gorilla/mux"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/config"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/flowstore"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/registry"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/runstore"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/pkg/types"
+)
+
+func newSSETestHandlers(t *testing.T) (*Handlers, runstore.RunStore) {
+	t.Helper()
+	store := runstore.NewMemoryStore(&runstore.Config{EventMaxLen: 1000, TTLSeconds: 3600})
+	h := NewHandlers(store, nil, nil, config.Load(), nil, &HandlerOptions{
+		Registry:  registry.NewMemoryRegistryWithDefaults(),
+		FlowStore: flowstore.NewMemoryStore(),
+	})
+	return h, store
+}
+
+// A reconnect with Last-Event-ID replays the run's prior events losslessly
+// before the live stream takes over.
+func TestStreamEvents_ReplaysHistoryFromLastEventID(t *testing.T) {
+	h, store := newSSETestHandlers(t)
+	bg := context.Background()
+
+	runID, err := store.CreateRun(bg, "sse", &types.Plan{Nodes: []types.NodeSpec{{ID: "n"}}}, "")
+	if err != nil {
+		t.Fatalf("CreateRun: %v", err)
+	}
+	for i := 0; i < 3; i++ {
+		if _, err := store.AppendEvent(bg, runID, &types.EventInput{
+			Type: types.EventTypeLog, NodeID: "n", Data: map[string]interface{}{"type": "log", "i": i},
+		}); err != nil {
+			t.Fatalf("AppendEvent: %v", err)
+		}
+	}
+
+	reqCtx, cancel := context.WithCancel(bg)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/"+runID+"/events", nil).WithContext(reqCtx)
+	req.Header.Set("Last-Event-ID", "0") // replay from the beginning
+	req = mux.SetURLVars(req, map[string]string{"id": runID})
+	rec := httptest.NewRecorder()
+
+	done := make(chan struct{})
+	go func() {
+		h.StreamEvents(rec, req)
+		close(done)
+	}()
+
+	time.Sleep(150 * time.Millisecond) // allow hello + historical writes
+	cancel()                           // unblock the stream loop (client disconnect)
+	<-done
+
+	body := rec.Body.String()
+	if got := strings.Count(body, "event: log"); got != 3 {
+		t.Errorf("replayed %d log events, want 3 (lossless resumption)\nbody:\n%s", got, body)
+	}
+	if !strings.Contains(body, "event: hello") {
+		t.Errorf("expected a hello event at stream start; body:\n%s", body)
+	}
+	if strings.Contains(body, "streaming not supported") {
+		t.Error("SSE handler returned 'streaming not supported' (Flusher assertion failed)")
+	}
+}
+
+// Streaming a non-existent run returns 404 rather than hanging.
+func TestStreamEvents_UnknownRun404(t *testing.T) {
+	h, _ := newSSETestHandlers(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/runs/nope/events", nil)
+	req = mux.SetURLVars(req, map[string]string{"id": "nope"})
+	rec := httptest.NewRecorder()
+
+	h.StreamEvents(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}

--- a/services/orchestrator-go/internal/runstore/event_parity_test.go
+++ b/services/orchestrator-go/internal/runstore/event_parity_test.go
@@ -1,0 +1,101 @@
+package runstore
+
+import (
+	"context"
+	"testing"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/pkg/types"
+)
+
+// The memory and redis stores must behave identically for the core run-loop
+// operations the SSE path depends on: create, append events, full replay, and
+// Last-Event-ID resumption.
+func TestEventStreamParity_MemoryVsRedis(t *testing.T) {
+	redisStore, _ := newTestRedisStore(t)
+	stores := map[string]RunStore{
+		"memory": NewMemoryStore(&Config{EventMaxLen: 1000, TTLSeconds: 3600}),
+		"redis":  redisStore,
+	}
+
+	type result struct {
+		full       int
+		fullTypes  []string
+		sinceFirst int
+		fromZero   int
+	}
+	results := map[string]result{}
+
+	ctx := context.Background()
+	for name, store := range stores {
+		runID, err := store.CreateRun(ctx, "parity", &types.Plan{Nodes: []types.NodeSpec{{ID: "n"}}}, "")
+		if err != nil {
+			t.Fatalf("[%s] CreateRun: %v", name, err)
+		}
+		for _, typ := range []types.EventType{types.EventTypeLog, types.EventTypeProgress, types.EventTypeLog} {
+			if _, err := store.AppendEvent(ctx, runID, &types.EventInput{
+				Type: typ, NodeID: "n", Data: map[string]interface{}{"type": string(typ)},
+			}); err != nil {
+				t.Fatalf("[%s] AppendEvent: %v", name, err)
+			}
+		}
+
+		full, err := store.GetEventsSince(ctx, runID, "")
+		if err != nil {
+			t.Fatalf("[%s] GetEventsSince(all): %v", name, err)
+		}
+		typesSeen := make([]string, len(full))
+		for i, e := range full {
+			typesSeen[i] = string(e.Type)
+		}
+
+		// Resume after the first event.
+		var sinceFirst int
+		if len(full) > 0 {
+			rest, err := store.GetEventsSince(ctx, runID, full[0].ID)
+			if err != nil {
+				t.Fatalf("[%s] GetEventsSince(first): %v", name, err)
+			}
+			sinceFirst = len(rest)
+		}
+
+		// "0" is the redis "from start" sentinel; both backends must replay all.
+		fromZeroEvents, err := store.GetEventsSince(ctx, runID, "0")
+		if err != nil {
+			t.Fatalf("[%s] GetEventsSince(\"0\"): %v", name, err)
+		}
+
+		results[name] = result{full: len(full), fullTypes: typesSeen, sinceFirst: sinceFirst, fromZero: len(fromZeroEvents)}
+	}
+
+	m, r := results["memory"], results["redis"]
+	if m.full != 3 || r.full != 3 {
+		t.Errorf("full event counts differ/wrong: memory=%d redis=%d, want 3 each", m.full, r.full)
+	}
+	if !equalStrings(m.fullTypes, r.fullTypes) {
+		t.Errorf("event type order differs: memory=%v redis=%v", m.fullTypes, r.fullTypes)
+	}
+	if m.sinceFirst != r.sinceFirst {
+		t.Errorf("Last-Event-ID resumption differs: memory=%d redis=%d events after first", m.sinceFirst, r.sinceFirst)
+	}
+	if m.sinceFirst != 2 {
+		t.Errorf("resumption after first event = %d, want 2", m.sinceFirst)
+	}
+	if m.fromZero != r.fromZero {
+		t.Errorf("\"0\" from-start replay differs: memory=%d redis=%d", m.fromZero, r.fromZero)
+	}
+	if m.fromZero != 3 {
+		t.Errorf("\"0\" from-start replay = %d, want 3 (replay all)", m.fromZero)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/services/orchestrator-go/internal/runstore/memory.go
+++ b/services/orchestrator-go/internal/runstore/memory.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"sync"
 	"time"
 
@@ -564,7 +565,26 @@ func (s *MemoryStore) GetEventsSince(ctx context.Context, runID string, lastEven
 		return result, nil
 	}
 
-	// Find events after lastEventID
+	// Numeric sequence comparison, matching the redis store: return events
+	// whose sequence is strictly greater than lastEventID. This makes "0" (and
+	// any id at/below the first) replay from the beginning, so SSE Last-Event-ID
+	// resumption behaves identically on both backends. Falls back to
+	// exact-match-then-after for non-numeric ids.
+	if lastSeq, err := strconv.ParseInt(lastEventID, 10, 64); err == nil {
+		var result []*types.Event
+		for _, evt := range run.events {
+			seq, perr := strconv.ParseInt(evt.ID, 10, 64)
+			if perr != nil {
+				continue
+			}
+			if seq > lastSeq {
+				result = append(result, evt)
+			}
+		}
+		return result, nil
+	}
+
+	// Find events after lastEventID (non-numeric id fallback).
 	var result []*types.Event
 	found := false
 	for _, evt := range run.events {


### PR DESCRIPTION
## Summary
Slice 2 (test & regression safety) for the core run-loop streaming path, plus a real parity bug fix and a CI coverage floor.

### Tests
- **SSE handler** (`sse.go` had zero tests): `Last-Event-ID` replay is lossless (hello + all prior events) and an unknown run returns 404 instead of hanging. Exercises the path fixed in #3.
- **runstore memory↔redis parity**: append, full replay, `Last-Event-ID` resumption, and the `"0"` from-start sentinel must behave identically on both backends.

### Bug fix (found by the parity test)
`MemoryStore.GetEventsSince` did **exact-id matching**, so `"0"` (the redis from-start sentinel) matched no event and replayed **nothing** — SSE reconnect behaved differently on the memory vs redis backend. It now uses numeric `seq > lastEventID` comparison, matching redis. Falls back to exact-match for non-numeric ids.

### CI coverage floor
`test-go` now enforces a per-service Go coverage floor (gateway **60%**, orchestrator **55%**, set just below current 62.8% / 56.7%) so coverage can't silently regress. Ratchet up over time.

> Note: these PRs merge on GitHub, which has no CI checks wired; the floor is enforced wherever the GitLab pipeline (`.gitlab-ci.yml`) runs.

Full `orchestrator-go` suite green (`-race`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)