### PR TITLE
test(frontend): cover SSE streaming pipeline + fix event drop on destroy

### DIFF
--- a/services/frontend/src/services/streaming/orchestratorSSE.test.ts
+++ b/services/frontend/src/services/streaming/orchestratorSSE.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { subscribeRunEvents } from './orchestratorSSE';
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+  url: string;
+  closed = false;
+  readyState = 1;
+  onopen: ((e?: any) => void) | null = null;
+  onmessage: ((e: any) => void) | null = null;
+  onerror: ((e: any) => void) | null = null;
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+  close() {
+    this.closed = true;
+  }
+}
+
+describe('subscribeRunEvents (native EventSource)', () => {
+  beforeEach(() => {
+    MockEventSource.instances = [];
+    vi.stubGlobal('EventSource', MockEventSource as any);
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  const opts = (extra: any = {}) => ({
+    baseUrl: 'http://gw.test',
+    transport: 'native' as const,
+    onEvent: vi.fn(),
+    ...extra,
+  });
+
+  it('opens an EventSource at the run events URL', () => {
+    subscribeRunEvents('run1', opts());
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toContain('/api/v1/runs/run1/events');
+    expect(MockEventSource.instances[0].url).toContain('gw.test');
+  });
+
+  it('delivers parsed events to onEvent and calls onOpen', () => {
+    const onEvent = vi.fn();
+    const onOpen = vi.fn();
+    subscribeRunEvents('run1', opts({ onEvent, onOpen }));
+    const es = MockEventSource.instances[0];
+
+    es.onopen?.();
+    expect(onOpen).toHaveBeenCalledOnce();
+
+    es.onmessage?.({ data: JSON.stringify({ type: 'log', m: 1 }), lastEventId: '5' });
+    expect(onEvent).toHaveBeenCalledOnce();
+    const [, parsed] = onEvent.mock.calls[0];
+    expect(parsed).toEqual({ type: 'log', m: 1 });
+  });
+
+  it('reconnects with backoff after an error, resuming from lastEventId', () => {
+    const onError = vi.fn();
+    subscribeRunEvents('run1', opts({ onError }));
+    const first = MockEventSource.instances[0];
+
+    // see an event so the client records a lastEventId to resume from
+    first.onmessage?.({ data: '{}', lastEventId: '7' });
+    first.onerror?.(new Error('drop'));
+    expect(onError).toHaveBeenCalled();
+    expect(first.closed).toBe(true);
+
+    // first backoff is 1000ms; before that, no new connection
+    expect(MockEventSource.instances).toHaveLength(1);
+    vi.advanceTimersByTime(1000);
+
+    expect(MockEventSource.instances).toHaveLength(2);
+    expect(MockEventSource.instances[1].url).toContain('fromId=7');
+  });
+
+  it('close() stops reconnection and closes the connection', () => {
+    const handle = subscribeRunEvents('run1', opts());
+    const first = MockEventSource.instances[0];
+
+    handle.close();
+    expect(first.closed).toBe(true);
+
+    // an error after close must not schedule a reconnect
+    first.onerror?.(new Error('late'));
+    vi.advanceTimersByTime(60_000);
+    expect(MockEventSource.instances).toHaveLength(1);
+  });
+});

--- a/services/frontend/src/services/streaming/parse.test.ts
+++ b/services/frontend/src/services/streaming/parse.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { parseRunEvent } from './parse';
+
+describe('parseRunEvent', () => {
+  it('derives seq from a numeric id and type from the event name', () => {
+    const e = parseRunEvent({ id: 42, event: 'node_status', data: { status: 'running' } });
+    expect(e.seq).toBe(42);
+    expect(e.type).toBe('node_status');
+    expect(e.id).toBe('42');
+    expect(e.data).toEqual({ status: 'running' });
+  });
+
+  it('infers type from data.type when no event name is given', () => {
+    const e = parseRunEvent({ id: 1, data: { type: 'log', message: 'hi' } });
+    expect(e.type).toBe('log');
+  });
+
+  it('infers type from data.kind as a fallback', () => {
+    const e = parseRunEvent({ id: 1, data: { kind: 'progress' } });
+    expect(e.type).toBe('progress');
+  });
+
+  it('defaults type to "message" when nothing identifies it', () => {
+    const e = parseRunEvent({ id: 1, data: {} });
+    expect(e.type).toBe('message');
+  });
+
+  it('JSON-parses string data on a plain frame', () => {
+    const e = parseRunEvent({ id: 2, event: 'log', data: '{"message":"parsed"}' });
+    expect(e.data).toEqual({ message: 'parsed' });
+  });
+
+  it('keeps malformed JSON string data as a raw string', () => {
+    const e = parseRunEvent({ id: 3, event: 'log', data: '{not valid json' });
+    expect(e.data).toBe('{not valid json');
+  });
+
+  it('extracts ts from data.ts/time/timestamp', () => {
+    expect(parseRunEvent({ id: 1, data: { ts: 'T1' } }).ts).toBe('T1');
+    expect(parseRunEvent({ id: 1, data: { timestamp: 'T2' } }).ts).toBe('T2');
+  });
+
+  it('extracts nodeId from node_id / nodeId / node', () => {
+    expect(parseRunEvent({ id: 1, data: { node_id: 'a' } }).nodeId).toBe('a');
+    expect(parseRunEvent({ id: 1, data: { nodeId: 'b' } }).nodeId).toBe('b');
+    expect(parseRunEvent({ id: 1, data: { node: 'c' } }).nodeId).toBe('c');
+  });
+
+  it('extracts log level from top-level and nested data.data', () => {
+    expect(parseRunEvent({ id: 1, data: { level: 'warn' } }).level).toBe('warn');
+    expect(parseRunEvent({ id: 1, data: { data: { level: 'error' } } }).level).toBe('error');
+  });
+
+  it('falls back to data.sequence/seq/offset when id is non-numeric', () => {
+    const e = parseRunEvent({ id: 'abc', data: { sequence: 7 } });
+    expect(e.seq).toBe(7);
+  });
+
+  it('uses a monotonic fallback counter when no id or payload seq exists', () => {
+    const a = parseRunEvent({ data: { type: 'log' } });
+    const b = parseRunEvent({ data: { type: 'log' } });
+    expect(Number.isFinite(a.seq)).toBe(true);
+    expect(b.seq).toBeGreaterThan(a.seq);
+  });
+
+  it('handles a browser MessageEvent: parses data and reads lastEventId', () => {
+    const me = new MessageEvent('message', {
+      data: JSON.stringify({ type: 'checkpoint', node_id: 'n1' }),
+      lastEventId: '9',
+    });
+    const e = parseRunEvent(me);
+    expect(e.id).toBe('9');
+    expect(e.seq).toBe(9);
+    expect(e.type).toBe('checkpoint');
+    expect(e.nodeId).toBe('n1');
+  });
+
+  it('leaves non-JSON MessageEvent data as text', () => {
+    const me = new MessageEvent('message', { data: 'plain text', lastEventId: '1' });
+    const e = parseRunEvent(me);
+    expect(e.data).toBe('plain text');
+  });
+});

--- a/services/frontend/src/transport/event-pipeline.test.ts
+++ b/services/frontend/src/transport/event-pipeline.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { EventPipeline } from './event-pipeline';
+import type { TransportEvent } from './connection-manager';
+
+function ev(seq: number): TransportEvent {
+  // TransportEvent shape is loose here; we only assert identity/order.
+  return { seq } as unknown as TransportEvent;
+}
+
+describe('EventPipeline', () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it('batches pushed events and flushes once after the interval, preserving order', () => {
+    const flushed: TransportEvent[][] = [];
+    const p = new EventPipeline({ flushInterval: 50, onFlush: (e) => flushed.push(e) });
+
+    p.push(ev(1));
+    p.push(ev(2));
+    p.push(ev(3));
+    expect(flushed).toHaveLength(0); // nothing yet
+    expect(p.getBufferSize()).toBe(3);
+
+    vi.advanceTimersByTime(50);
+
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0].map((e: any) => e.seq)).toEqual([1, 2, 3]);
+    expect(p.hasPending()).toBe(false);
+  });
+
+  it('force-flushes when the buffer reaches maxBufferSize', () => {
+    const flushed: TransportEvent[][] = [];
+    const p = new EventPipeline({ flushInterval: 50, maxBufferSize: 2, onFlush: (e) => flushed.push(e) });
+
+    p.push(ev(1));
+    expect(flushed).toHaveLength(0);
+    p.push(ev(2)); // hits maxBufferSize -> immediate flush
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0]).toHaveLength(2);
+  });
+
+  it('flush() is a no-op when the buffer is empty', () => {
+    const onFlush = vi.fn();
+    const p = new EventPipeline({ onFlush });
+    p.flush();
+    expect(onFlush).not.toHaveBeenCalled();
+  });
+
+  it('routes onFlush handler errors to onError instead of throwing', () => {
+    const onError = vi.fn();
+    const p = new EventPipeline({
+      flushInterval: 10,
+      onFlush: () => { throw new Error('boom'); },
+      onError,
+    });
+    p.push(ev(1));
+    expect(() => vi.advanceTimersByTime(10)).not.toThrow();
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+
+  it('tracks stats: received, flushed, flushCount, averageBatchSize', () => {
+    const p = new EventPipeline({ flushInterval: 10, onFlush: () => {} });
+    p.push(ev(1));
+    p.push(ev(2));
+    vi.advanceTimersByTime(10);
+    p.push(ev(3));
+    vi.advanceTimersByTime(10);
+
+    const s = p.getStats();
+    expect(s.totalReceived).toBe(3);
+    expect(s.totalFlushed).toBe(3);
+    expect(s.flushCount).toBe(2);
+    expect(s.averageBatchSize).toBeCloseTo(1.5);
+  });
+
+  it('flushes remaining buffered events on destroy (no silent drop)', () => {
+    const flushed: TransportEvent[][] = [];
+    const p = new EventPipeline({ flushInterval: 1000, onFlush: (e) => flushed.push(e) });
+    p.push(ev(1));
+    p.push(ev(2));
+
+    p.destroy(); // must flush the 2 buffered events before tearing down
+
+    expect(flushed).toHaveLength(1);
+    expect(flushed[0]).toHaveLength(2);
+  });
+
+  it('ignores pushes after destroy', () => {
+    const flushed: TransportEvent[][] = [];
+    const p = new EventPipeline({ flushInterval: 10, onFlush: (e) => flushed.push(e) });
+    p.destroy();
+    p.push(ev(1));
+    vi.advanceTimersByTime(50);
+    expect(flushed).toHaveLength(0);
+  });
+});

--- a/services/frontend/src/transport/event-pipeline.ts
+++ b/services/frontend/src/transport/event-pipeline.ts
@@ -209,12 +209,14 @@ export class EventPipeline {
   destroy(): void {
     if (this.isDestroyed) return;
 
-    this.isDestroyed = true;
-
-    // Flush any remaining events
+    // Flush any remaining events BEFORE marking destroyed — flush() early-returns
+    // when isDestroyed is set, so flushing first avoids silently dropping the
+    // buffered tail on teardown.
     if (this.buffer.length > 0) {
       this.flush();
     }
+
+    this.isDestroyed = true;
 
     // Clear timeout
     if (this.flushTimeoutId !== null) {

--- a/services/frontend/vitest.config.ts
+++ b/services/frontend/vitest.config.ts
@@ -25,8 +25,23 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       reporter: ['text', 'text-summary', 'lcov'],
-      include: ['src/components/**', 'src/stores/**', 'src/hooks/**'],
+      include: [
+        'src/components/**',
+        'src/stores/**',
+        'src/hooks/**',
+        'src/services/streaming/**',
+        'src/transport/**',
+      ],
       exclude: ['**/__tests__/**', '**/*.test.*', '**/*.spec.*', '**/e2e/**'],
+      // Per-file floors for the critical streaming/transport modules, set just
+      // below current coverage so they cannot silently regress. Only the keyed
+      // files are gated; untested neighbors are reported but not enforced.
+      // Ratchet up as coverage improves.
+      thresholds: {
+        'src/services/streaming/parse.ts': { statements: 55, branches: 80, functions: 50, lines: 55 },
+        'src/services/streaming/orchestratorSSE.ts': { statements: 40, branches: 50, functions: 75, lines: 40 },
+        'src/transport/event-pipeline.ts': { statements: 70, branches: 70, functions: 70, lines: 70 },
+      },
     },
   },
 });


### PR DESCRIPTION
## Summary
Slice 2 (test & regression safety), frontend half. The streaming/transport modules the run-monitoring UI depends on had **zero tests** (acceptance #4).

- **`parse.ts`** (`parseRunEvent`): id/seq derivation, type inference (event name → data.type → data.kind), JSON vs raw string data, ts/nodeId/level extraction, the browser `MessageEvent` path, and the monotonic fallback counter.
- **`event-pipeline.ts`** (`EventPipeline`): batching + order preservation, `maxBufferSize` force-flush, empty-flush no-op, `onError` routing, stats, and the post-destroy push guard.
- **`orchestratorSSE.ts`** (`subscribeRunEvents`): opens the correct events URL, delivers parsed events, **reconnects with backoff resuming from `fromId`**, and `close()` stops reconnection — via a mock `EventSource` + fake timers.

## Bug fix (found by the pipeline test)
`EventPipeline.destroy()` set `isDestroyed = true` **before** calling `flush()`, but `flush()` early-returns when destroyed — so any buffered tail was **silently dropped on teardown**, contradicting its "Flush any remaining events" contract. Now it flushes first.

## CI
vitest **per-file coverage floors** for the three modules (just below current: parse 55%, orchestratorSSE 40%, event-pipeline 70%) so they can't silently regress; `src/services/streaming/**` and `src/transport/**` added to the coverage include set. `tsc --noEmit` clean.

This completes Slice 2 alongside the Go half (#9: SSE handler + runstore parity tests + coverage floor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)