### PR TITLE
feat(orchestrator): enforce API-key scopes per endpoint

### DIFF
--- a/services/orchestrator-go/internal/api/routes.go
+++ b/services/orchestrator-go/internal/api/routes.go
@@ -55,6 +55,9 @@ func (s *Server) setupRoutes() {
 	// Apply auth middleware to API subrouter if configured
 	if s.authMiddleware != nil {
 		api.Use(s.authMiddleware.Handler)
+		// Enforce API-key scopes per method (write for mutations, read for GETs).
+		// No-op for OIDC users and unscoped/legacy keys.
+		api.Use(auth.ScopeEnforcementMiddleware)
 	}
 
 	// Audit logging for authenticated API operations

--- a/services/orchestrator-go/internal/auth/middleware.go
+++ b/services/orchestrator-go/internal/auth/middleware.go
@@ -100,9 +100,12 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 				m.unauthorized(w, "invalid api key")
 				return
 			}
-			// Inject API key owner as claims
+			// Inject API key owner + scopes as claims so downstream scope
+			// enforcement can authorize per-endpoint.
 			claims := &Claims{
-				Email: apiKey.Owner,
+				Email:      apiKey.Owner,
+				Scopes:     apiKey.Scopes,
+				AuthMethod: AuthMethodAPIKey,
 			}
 			ctx := context.WithValue(r.Context(), claimsContextKey, claims)
 			// Also set X-User-Email header so getOwnerFromRequest works
@@ -144,8 +147,41 @@ func (m *Middleware) Handler(next http.Handler) http.Handler {
 		}
 
 		// Add claims to context
+		claims.AuthMethod = AuthMethodOIDC
 		ctx := context.WithValue(r.Context(), claimsContextKey, claims)
 		next.ServeHTTP(w, r.WithContext(ctx))
+	})
+}
+
+// ScopeEnforcementMiddleware enforces API-key scopes per request method:
+// mutating methods (POST/PUT/PATCH/DELETE) require the "write" scope, reads
+// require "read". It applies ONLY to API-key principals — OIDC users and
+// auth-disabled requests are governed by roles/groups, not scopes. For
+// backward compatibility, API keys that declare no scopes are treated as
+// unrestricted (legacy behavior); only keys that declare scopes are enforced.
+func ScopeEnforcementMiddleware(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims := GetClaims(r.Context())
+		if claims == nil || claims.AuthMethod != AuthMethodAPIKey || len(claims.Scopes) == 0 {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		required := ScopeRead
+		switch r.Method {
+		case http.MethodPost, http.MethodPut, http.MethodPatch, http.MethodDelete:
+			required = ScopeWrite
+		}
+
+		if !claims.HasScope(required) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusForbidden)
+			json.NewEncoder(w).Encode(map[string]string{
+				"error": "api key missing required scope: " + required,
+			})
+			return
+		}
+		next.ServeHTTP(w, r)
 	})
 }
 

--- a/services/orchestrator-go/internal/auth/oauth.go
+++ b/services/orchestrator-go/internal/auth/oauth.go
@@ -186,8 +186,38 @@ type Claims struct {
 	Expiry        time.Time `json:"exp,omitempty"`
 	IssuedAt      time.Time `json:"iat,omitempty"`
 
+	// Scopes carries the authorization scopes for the principal. Populated for
+	// API-key authentication; empty for OIDC users (governed by roles/groups).
+	Scopes []string `json:"scopes,omitempty"`
+	// AuthMethod records how the principal authenticated ("apikey" or "oidc").
+	AuthMethod string `json:"auth_method,omitempty"`
+
 	// Raw is the underlying ID token
 	Raw *oidc.IDToken `json:"-"`
+}
+
+// Auth method markers and API-key scope identifiers.
+const (
+	AuthMethodOIDC   = "oidc"
+	AuthMethodAPIKey = "apikey"
+
+	ScopeRead  = "read"
+	ScopeWrite = "write"
+	ScopeAdmin = "admin"
+)
+
+// HasScope reports whether the principal holds the given scope. A "*" or
+// "admin" scope grants everything, and "write" implies "read".
+func (c *Claims) HasScope(scope string) bool {
+	for _, s := range c.Scopes {
+		if s == scope || s == "*" || s == ScopeAdmin {
+			return true
+		}
+		if scope == ScopeRead && s == ScopeWrite {
+			return true
+		}
+	}
+	return false
 }
 
 // HasRole checks if the user has a specific role.

--- a/services/orchestrator-go/internal/auth/scope_test.go
+++ b/services/orchestrator-go/internal/auth/scope_test.go
@@ -1,0 +1,88 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClaims_HasScope(t *testing.T) {
+	cases := []struct {
+		name   string
+		scopes []string
+		want   string
+		ok     bool
+	}{
+		{"exact write", []string{"write"}, ScopeWrite, true},
+		{"write implies read", []string{"write"}, ScopeRead, true},
+		{"read does not imply write", []string{"read"}, ScopeWrite, false},
+		{"wildcard grants write", []string{"*"}, ScopeWrite, true},
+		{"admin grants write", []string{"admin"}, ScopeWrite, true},
+		{"missing scope", []string{"read"}, ScopeWrite, false},
+		{"empty", nil, ScopeRead, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			c := &Claims{Scopes: tc.scopes}
+			if got := c.HasScope(tc.want); got != tc.ok {
+				t.Errorf("HasScope(%q) with %v = %v, want %v", tc.want, tc.scopes, got, tc.ok)
+			}
+		})
+	}
+}
+
+// helper: run a request with given claims through ScopeEnforcementMiddleware.
+func runWithClaims(method string, claims *Claims) int {
+	reached := false
+	h := ScopeEnforcementMiddleware(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		reached = true
+		w.WriteHeader(http.StatusOK)
+	}))
+	req := httptest.NewRequest(method, "/api/v1/runs", nil)
+	if claims != nil {
+		req = req.WithContext(context.WithValue(req.Context(), claimsContextKey, claims))
+	}
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, req)
+	_ = reached
+	return rec.Code
+}
+
+func TestScopeEnforcement_WriteRequiresWriteScope(t *testing.T) {
+	readOnly := &Claims{AuthMethod: AuthMethodAPIKey, Scopes: []string{ScopeRead}}
+	if code := runWithClaims(http.MethodPost, readOnly); code != http.StatusForbidden {
+		t.Errorf("read-only key POST = %d, want 403", code)
+	}
+	if code := runWithClaims(http.MethodDelete, readOnly); code != http.StatusForbidden {
+		t.Errorf("read-only key DELETE = %d, want 403", code)
+	}
+	// read-only key may still GET
+	if code := runWithClaims(http.MethodGet, readOnly); code != http.StatusOK {
+		t.Errorf("read-only key GET = %d, want 200", code)
+	}
+}
+
+func TestScopeEnforcement_WriteScopeAllowed(t *testing.T) {
+	writer := &Claims{AuthMethod: AuthMethodAPIKey, Scopes: []string{ScopeWrite}}
+	if code := runWithClaims(http.MethodPost, writer); code != http.StatusOK {
+		t.Errorf("write key POST = %d, want 200", code)
+	}
+}
+
+func TestScopeEnforcement_LegacyUnscopedKeyUnrestricted(t *testing.T) {
+	legacy := &Claims{AuthMethod: AuthMethodAPIKey} // no scopes declared
+	if code := runWithClaims(http.MethodPost, legacy); code != http.StatusOK {
+		t.Errorf("legacy unscoped key POST = %d, want 200 (backward compat)", code)
+	}
+}
+
+func TestScopeEnforcement_OIDCAndAnonymousBypass(t *testing.T) {
+	oidc := &Claims{AuthMethod: AuthMethodOIDC, Scopes: []string{ScopeRead}}
+	if code := runWithClaims(http.MethodPost, oidc); code != http.StatusOK {
+		t.Errorf("OIDC user POST = %d, want 200 (scopes are an API-key concept)", code)
+	}
+	if code := runWithClaims(http.MethodPost, nil); code != http.StatusOK {
+		t.Errorf("no-claims (auth disabled) POST = %d, want 200", code)
+	}
+}


### PR DESCRIPTION
## Summary
Slice 6 (security). API keys carried a `Scopes` field that was **stored but never enforced**: on authentication the middleware built `Claims` from only the key's owner and **discarded its scopes**, so any valid key had full access to every endpoint.

Now:
- the key's scopes (+ an auth-method marker) are propagated into `Claims`
- `ScopeEnforcementMiddleware` on the API subrouter authorizes by method — mutating requests (POST/PUT/PATCH/DELETE) require `write`, reads require `read` (`write` implies `read`; `*`/`admin` grant all)

Enforcement applies **only to API-key principals** — OIDC users and auth-disabled requests are governed by roles/groups, not scopes. For backward compatibility, API keys that declare **no scopes** remain unrestricted (legacy), so only keys that opt into scopes are constrained — existing keys keep working.

## Tests
- `HasScope` semantics (exact, write⇒read, wildcard/admin, negatives)
- middleware: read-only key → **403 on writes** but 200 on reads; write key → 200; legacy unscoped key → 200; OIDC/anonymous → 200
- full `orchestrator-go` suite green

## Remaining Slice 6 (follow-ups)
Agent secrets via K8s Secrets instead of plaintext env (needs the k8s driver path / cluster to validate); subprocess resource limits; CI dependency + secret scanning. Best landed alongside the k8s-mode work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)