### PR TITLE
fix(orchestrator): harden webhook auth + dedup cron triggers

### DIFF
--- a/services/orchestrator-go/internal/api/handlers_m5m6.go
+++ b/services/orchestrator-go/internal/api/handlers_m5m6.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -190,7 +191,8 @@ func (h *Handlers) TriggerWebhook(w http.ResponseWriter, r *http.Request) {
 			providedToken = auth[7:]
 		}
 	}
-	if providedToken != expectedToken {
+	// Constant-time comparison to avoid leaking the token via timing.
+	if subtle.ConstantTimeCompare([]byte(providedToken), []byte(expectedToken)) != 1 {
 		h.respondError(w, r, http.StatusForbidden, "invalid webhook token", errors.New("token mismatch"))
 		return
 	}

--- a/services/orchestrator-go/internal/api/webhook_test.go
+++ b/services/orchestrator-go/internal/api/webhook_test.go
@@ -1,0 +1,82 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/config"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/flowstore"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/registry"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/runstore"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/scheduler"
+)
+
+func newWebhookTestHandlers(t *testing.T) (*Handlers, flowstore.FlowStore) {
+	t.Helper()
+	store := runstore.NewMemoryStore(&runstore.Config{EventMaxLen: 100, TTLSeconds: 3600})
+	flows := flowstore.NewMemoryStore()
+	sched := scheduler.New(store, nil, nil, nil, nil)
+	h := NewHandlers(store, sched, nil, config.Load(), nil, &HandlerOptions{
+		Registry:  registry.NewMemoryRegistryWithDefaults(),
+		FlowStore: flows,
+	})
+	return h, flows
+}
+
+func triggerWebhook(h *Handlers, flowID, tokenHeader, tokenValue string) int {
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/trigger/"+flowID, nil)
+	if tokenHeader != "" {
+		req.Header.Set(tokenHeader, tokenValue)
+	}
+	req = mux.SetURLVars(req, map[string]string{"flowId": flowID})
+	rec := httptest.NewRecorder()
+	h.TriggerWebhook(rec, req)
+	return rec.Code
+}
+
+func TestTriggerWebhook_RejectsMissingAndInvalidToken(t *testing.T) {
+	h, flows := newWebhookTestHandlers(t)
+	_, err := flows.Create(context.Background(), &flowstore.CreateFlowRequest{
+		ID:       "f1",
+		Name:     "flow",
+		Graph:    json.RawMessage(`{"nodes":[]}`),
+		Metadata: map[string]any{"webhook_token": "s3cret"},
+	})
+	if err != nil {
+		t.Fatalf("Create flow: %v", err)
+	}
+
+	if code := triggerWebhook(h, "f1", "", ""); code != http.StatusForbidden {
+		t.Errorf("missing token = %d, want 403", code)
+	}
+	if code := triggerWebhook(h, "f1", "X-Webhook-Token", "wrong"); code != http.StatusForbidden {
+		t.Errorf("invalid token = %d, want 403", code)
+	}
+	if code := triggerWebhook(h, "f1", "Authorization", "Bearer wrong"); code != http.StatusForbidden {
+		t.Errorf("invalid bearer = %d, want 403", code)
+	}
+}
+
+func TestTriggerWebhook_NoTokenConfigured(t *testing.T) {
+	h, flows := newWebhookTestHandlers(t)
+	_, _ = flows.Create(context.Background(), &flowstore.CreateFlowRequest{
+		ID:    "f2",
+		Name:  "flow",
+		Graph: json.RawMessage(`{"nodes":[]}`),
+	})
+	if code := triggerWebhook(h, "f2", "X-Webhook-Token", "anything"); code != http.StatusForbidden {
+		t.Errorf("flow without configured webhook = %d, want 403", code)
+	}
+}
+
+func TestTriggerWebhook_UnknownFlow404(t *testing.T) {
+	h, _ := newWebhookTestHandlers(t)
+	if code := triggerWebhook(h, "nope", "X-Webhook-Token", "x"); code != http.StatusNotFound {
+		t.Errorf("unknown flow = %d, want 404", code)
+	}
+}

--- a/services/orchestrator-go/internal/scheduler/cron.go
+++ b/services/orchestrator-go/internal/scheduler/cron.go
@@ -30,13 +30,13 @@ type Schedule struct {
 
 // CronRunner evaluates cron schedules every minute and triggers flow runs.
 type CronRunner struct {
-	scheduler  *Scheduler
-	flowStore  flowstore.FlowStore
-	runStore   runstore.RunStore
-	schedules  map[string]*Schedule
-	mu         sync.RWMutex
-	logger     *slog.Logger
-	stopCh     chan struct{}
+	scheduler *Scheduler
+	flowStore flowstore.FlowStore
+	runStore  runstore.RunStore
+	schedules map[string]*Schedule
+	mu        sync.RWMutex
+	logger    *slog.Logger
+	stopCh    chan struct{}
 }
 
 // NewCronRunner creates a new cron runner.
@@ -143,10 +143,19 @@ func (cr *CronRunner) evaluate(now time.Time) {
 		if !s.Enabled {
 			continue
 		}
-		if cronMatches(s.Cron, now) {
-			copy := *s
-			toRun = append(toRun, &copy)
+		if !cronMatches(s.Cron, now) {
+			continue
 		}
+		// Dedup within the minute: skip if we already triggered this schedule
+		// for the current minute. This prevents a double-fire (e.g. the initial
+		// aligned evaluate plus the first ticker tick) and makes missed-tick
+		// behavior explicit — a tick missed while the orchestrator was down is
+		// simply skipped (no catch-up), since cronMatches only matches "now".
+		if s.LastRunAt != nil && s.LastRunAt.Truncate(time.Minute).Equal(now.Truncate(time.Minute)) {
+			continue
+		}
+		copy := *s
+		toRun = append(toRun, &copy)
 	}
 	cr.mu.RUnlock()
 

--- a/services/orchestrator-go/internal/scheduler/cron_dedup_test.go
+++ b/services/orchestrator-go/internal/scheduler/cron_dedup_test.go
@@ -1,0 +1,74 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/flowstore"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/runstore"
+)
+
+// A schedule must fire at most once per minute even if evaluate() runs twice
+// for the same minute (e.g. the initial aligned evaluate plus the first ticker
+// tick). This also pins the missed-tick policy: cronMatches only matches the
+// current minute, so a tick missed during downtime is skipped, not caught up.
+func TestCron_NoDuplicateTriggerWithinMinute(t *testing.T) {
+	store := runstore.NewMemoryStore(nil)
+	flows := flowstore.NewMemoryStore()
+	sched := New(store, &mockDriver{}, testCommandResolver, nil, slog.Default())
+	cr := NewCronRunner(sched, flows, store, slog.Default())
+
+	ctx := context.Background()
+	if _, err := flows.Create(ctx, &flowstore.CreateFlowRequest{
+		ID:    "f1",
+		Name:  "cronflow",
+		Graph: json.RawMessage(`{"nodes":[{"id":"n","type":"agent","command":["x"]}]}`),
+	}); err != nil {
+		t.Fatalf("Create flow: %v", err)
+	}
+	if err := cr.AddSchedule(&Schedule{ID: "s1", FlowID: "f1", Cron: "* * * * *", Enabled: true}); err != nil {
+		t.Fatalf("AddSchedule: %v", err)
+	}
+
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	cr.evaluate(now)
+	cr.evaluate(now) // same minute again — must be deduped
+
+	ids, err := store.ListRuns(ctx)
+	if err != nil {
+		t.Fatalf("ListRuns: %v", err)
+	}
+	if len(ids) != 1 {
+		t.Fatalf("schedule fired %d times in one minute, want exactly 1", len(ids))
+	}
+
+	// A new minute triggers again.
+	cr.evaluate(now.Add(time.Minute))
+	ids, _ = store.ListRuns(ctx)
+	if len(ids) != 2 {
+		t.Fatalf("after next minute, total runs = %d, want 2", len(ids))
+	}
+}
+
+// A disabled schedule never fires.
+func TestCron_DisabledScheduleDoesNotFire(t *testing.T) {
+	store := runstore.NewMemoryStore(nil)
+	flows := flowstore.NewMemoryStore()
+	sched := New(store, &mockDriver{}, testCommandResolver, nil, slog.Default())
+	cr := NewCronRunner(sched, flows, store, slog.Default())
+
+	ctx := context.Background()
+	_, _ = flows.Create(ctx, &flowstore.CreateFlowRequest{
+		ID: "f1", Name: "f", Graph: json.RawMessage(`{"nodes":[{"id":"n","type":"agent","command":["x"]}]}`),
+	})
+	_ = cr.AddSchedule(&Schedule{ID: "s1", FlowID: "f1", Cron: "* * * * *", Enabled: false})
+
+	cr.evaluate(time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC))
+	ids, _ := store.ListRuns(ctx)
+	if len(ids) != 0 {
+		t.Fatalf("disabled schedule fired %d runs, want 0", len(ids))
+	}
+}


### PR DESCRIPTION
## Summary
Trigger-path robustness (Slice 5). Webhook auth and cron triggering were both **untested**.

### Webhook
- **Constant-time token comparison** (`crypto/subtle`) instead of `!=`, removing a timing side-channel on the secret.
- Tests: missing token, wrong `X-Webhook-Token`, and wrong `Bearer` all **403**; flow with no configured webhook **403**; unknown flow **404**.
- Token rotation already works by re-POSTing `CreateWebhook` (it overwrites the stored token).

### Cron
- **Dedup within the minute**: a schedule fires at most once per minute even if `evaluate()` runs twice for the same minute (initial aligned evaluate + first ticker tick), guarded by `LastRunAt`'s minute.
- This pins the **missed-tick policy** explicitly: `cronMatches` only matches the current minute, so a tick missed while the orchestrator was down is **skipped** (no catch-up).
- Tests: no duplicate trigger within a minute, fires again the next minute, disabled schedule never fires.

## Follow-up (remaining Slice 5)
Cron schedules are still **in-memory only** and lost on restart — persistence + reload is a separate, larger change (needs a persistence-layer decision, and ties into the single-runner/HA story).

🤖 Generated with [Claude Code](https://claude.com/claude-code)