### PR TITLE
feat(orchestrator): persist cron schedules across restart

### DIFF
--- a/services/orchestrator-go/cmd/orchestrator/main.go
+++ b/services/orchestrator-go/cmd/orchestrator/main.go
@@ -176,6 +176,19 @@ func main() {
 
 	// Initialize CronRunner for scheduled runs
 	cronRunner := scheduler.NewCronRunner(sched, flows, store, logger.With(slog.String("component", "cron")))
+	// Persist schedules to Redis (when configured) so they survive restarts.
+	if cfg.RunStoreType == "redis" {
+		if opts, oerr := factories.ResolveRedisOptions(cfg); oerr != nil {
+			logger.Warn("cron: failed to resolve redis options; schedules will be in-memory only", "error", oerr)
+		} else {
+			cronRunner.SetScheduleStore(scheduler.NewRedisScheduleStore(redis.NewClient(opts)))
+			if n, lerr := cronRunner.LoadSchedules(context.Background()); lerr != nil {
+				logger.Warn("cron: failed to load persisted schedules", "error", lerr)
+			} else if n > 0 {
+				logger.Info("cron: loaded persisted schedules", "count", n)
+			}
+		}
+	}
 	cronRunner.Start()
 	defer cronRunner.Stop()
 	logger.Info("cron runner started")

--- a/services/orchestrator-go/internal/scheduler/cron.go
+++ b/services/orchestrator-go/internal/scheduler/cron.go
@@ -34,6 +34,7 @@ type CronRunner struct {
 	flowStore flowstore.FlowStore
 	runStore  runstore.RunStore
 	schedules map[string]*Schedule
+	store     ScheduleStore // optional persistence; nil = in-memory only
 	mu        sync.RWMutex
 	logger    *slog.Logger
 	stopCh    chan struct{}
@@ -49,6 +50,39 @@ func NewCronRunner(sched *Scheduler, fs flowstore.FlowStore, rs runstore.RunStor
 		logger:    logger,
 		stopCh:    make(chan struct{}),
 	}
+}
+
+// SetScheduleStore attaches a persistence backend so schedules survive
+// restarts. Must be called before LoadSchedules/Start.
+func (cr *CronRunner) SetScheduleStore(store ScheduleStore) {
+	cr.store = store
+}
+
+// LoadSchedules repopulates the in-memory schedule set from the persistence
+// backend (if any). Intended to run once at startup before Start. Schedules
+// with an invalid cron expression are skipped with a warning. Returns the
+// number of schedules loaded.
+func (cr *CronRunner) LoadSchedules(ctx context.Context) (int, error) {
+	if cr.store == nil {
+		return 0, nil
+	}
+	scheds, err := cr.store.List(ctx)
+	if err != nil {
+		return 0, err
+	}
+	cr.mu.Lock()
+	defer cr.mu.Unlock()
+	loaded := 0
+	for _, s := range scheds {
+		if _, perr := parseCron(s.Cron); perr != nil {
+			cr.logger.Warn("skipping persisted schedule with invalid cron",
+				slog.String("schedule_id", s.ID), slog.String("cron", s.Cron), slog.Any("error", perr))
+			continue
+		}
+		cr.schedules[s.ID] = s
+		loaded++
+	}
+	return loaded, nil
 }
 
 // Start begins the cron evaluation loop.
@@ -69,20 +103,36 @@ func (cr *CronRunner) AddSchedule(sched *Schedule) error {
 	}
 
 	cr.mu.Lock()
-	defer cr.mu.Unlock()
 	cr.schedules[sched.ID] = sched
+	cr.mu.Unlock()
+
+	// Persist so the schedule survives a restart.
+	if cr.store != nil {
+		if err := cr.store.Save(context.Background(), sched); err != nil {
+			return fmt.Errorf("persist schedule: %w", err)
+		}
+	}
 	return nil
 }
 
 // RemoveSchedule removes a schedule by ID.
 func (cr *CronRunner) RemoveSchedule(id string) error {
 	cr.mu.Lock()
-	defer cr.mu.Unlock()
+	_, ok := cr.schedules[id]
+	if ok {
+		delete(cr.schedules, id)
+	}
+	cr.mu.Unlock()
 
-	if _, ok := cr.schedules[id]; !ok {
+	if !ok {
 		return fmt.Errorf("schedule %s not found", id)
 	}
-	delete(cr.schedules, id)
+
+	if cr.store != nil {
+		if err := cr.store.Delete(context.Background(), id); err != nil {
+			return fmt.Errorf("delete persisted schedule: %w", err)
+		}
+	}
 	return nil
 }
 
@@ -217,13 +267,25 @@ func (cr *CronRunner) triggerRun(sched *Schedule, triggerTime time.Time) {
 	}
 
 	// Update schedule metadata
+	var updated *Schedule
 	cr.mu.Lock()
 	if s, ok := cr.schedules[sched.ID]; ok {
 		s.LastRunAt = &triggerTime
 		s.LastRunID = runID
 		s.UpdatedAt = time.Now().UTC()
+		clone := *s
+		updated = &clone
 	}
 	cr.mu.Unlock()
+
+	// Persist the updated last-run metadata so dedup/missed-tick state survives
+	// a restart (best-effort: a persistence error must not fail the run).
+	if cr.store != nil && updated != nil {
+		if err := cr.store.Save(context.Background(), updated); err != nil {
+			cr.logger.Warn("cron: failed to persist schedule last-run metadata",
+				slog.String("schedule_id", updated.ID), slog.Any("error", err))
+		}
+	}
 
 	cr.logger.Info("cron: triggered run",
 		slog.String("schedule_id", sched.ID),

--- a/services/orchestrator-go/internal/scheduler/schedule_store.go
+++ b/services/orchestrator-go/internal/scheduler/schedule_store.go
@@ -1,0 +1,65 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/redis/go-redis/v9"
+)
+
+// ScheduleStore persists cron schedules so they survive an orchestrator
+// restart. A nil store means schedules are kept in memory only (legacy
+// behavior) and are lost on restart.
+type ScheduleStore interface {
+	Save(ctx context.Context, sched *Schedule) error
+	Delete(ctx context.Context, id string) error
+	List(ctx context.Context) ([]*Schedule, error)
+}
+
+// RedisScheduleStore persists schedules in a single Redis hash keyed by
+// schedule ID (field) -> JSON (value).
+type RedisScheduleStore struct {
+	client *redis.Client
+	key    string
+}
+
+// NewRedisScheduleStore creates a Redis-backed schedule store.
+func NewRedisScheduleStore(client *redis.Client) *RedisScheduleStore {
+	return &RedisScheduleStore{client: client, key: "schedules"}
+}
+
+func (s *RedisScheduleStore) Save(ctx context.Context, sched *Schedule) error {
+	b, err := json.Marshal(sched)
+	if err != nil {
+		return fmt.Errorf("marshal schedule: %w", err)
+	}
+	if err := s.client.HSet(ctx, s.key, sched.ID, b).Err(); err != nil {
+		return fmt.Errorf("persist schedule: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisScheduleStore) Delete(ctx context.Context, id string) error {
+	if err := s.client.HDel(ctx, s.key, id).Err(); err != nil {
+		return fmt.Errorf("delete schedule: %w", err)
+	}
+	return nil
+}
+
+func (s *RedisScheduleStore) List(ctx context.Context) ([]*Schedule, error) {
+	m, err := s.client.HGetAll(ctx, s.key).Result()
+	if err != nil {
+		return nil, fmt.Errorf("list schedules: %w", err)
+	}
+	out := make([]*Schedule, 0, len(m))
+	for _, v := range m {
+		var sc Schedule
+		if err := json.Unmarshal([]byte(v), &sc); err != nil {
+			// Skip corrupt entries rather than failing the whole load.
+			continue
+		}
+		out = append(out, &sc)
+	}
+	return out, nil
+}

--- a/services/orchestrator-go/internal/scheduler/schedule_store_test.go
+++ b/services/orchestrator-go/internal/scheduler/schedule_store_test.go
@@ -1,0 +1,115 @@
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/flowstore"
+	"github.com/flexinfer/mentatlab/services/orchestrator-go/internal/runstore"
+)
+
+func newTestScheduleStore(t *testing.T) (*RedisScheduleStore, *redis.Client) {
+	t.Helper()
+	mr, err := miniredis.Run()
+	if err != nil {
+		t.Fatalf("miniredis: %v", err)
+	}
+	t.Cleanup(mr.Close)
+	client := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	return NewRedisScheduleStore(client), client
+}
+
+func TestRedisScheduleStore_RoundTrip(t *testing.T) {
+	store, _ := newTestScheduleStore(t)
+	ctx := context.Background()
+
+	if err := store.Save(ctx, &Schedule{ID: "s1", FlowID: "f1", Cron: "* * * * *", Enabled: true}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	if err := store.Save(ctx, &Schedule{ID: "s2", FlowID: "f2", Cron: "0 * * * *", Enabled: false}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	list, err := store.List(ctx)
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(list) != 2 {
+		t.Fatalf("List len = %d, want 2", len(list))
+	}
+
+	if err := store.Delete(ctx, "s1"); err != nil {
+		t.Fatalf("Delete: %v", err)
+	}
+	list, _ = store.List(ctx)
+	if len(list) != 1 || list[0].ID != "s2" {
+		t.Fatalf("after delete: %+v, want only s2", list)
+	}
+}
+
+// A schedule added to one runner must be reloaded by a fresh runner backed by
+// the same store — i.e. it survives an orchestrator restart.
+func TestCronRunner_SchedulesSurviveRestart(t *testing.T) {
+	store, _ := newTestScheduleStore(t)
+	ctx := context.Background()
+
+	mkRunner := func() *CronRunner {
+		s := runstore.NewMemoryStore(nil)
+		cr := NewCronRunner(New(s, &mockDriver{}, testCommandResolver, nil, slog.Default()),
+			flowstore.NewMemoryStore(), s, slog.Default())
+		cr.SetScheduleStore(store)
+		return cr
+	}
+
+	// First process: add a schedule (persisted via the store).
+	r1 := mkRunner()
+	if err := r1.AddSchedule(&Schedule{ID: "s1", FlowID: "f1", Cron: "*/5 * * * *", Enabled: true}); err != nil {
+		t.Fatalf("AddSchedule: %v", err)
+	}
+
+	// Second process (restart): a brand-new runner loads from the same store.
+	r2 := mkRunner()
+	if got := len(r2.ListSchedules()); got != 0 {
+		t.Fatalf("fresh runner should start empty, had %d", got)
+	}
+	n, err := r2.LoadSchedules(ctx)
+	if err != nil {
+		t.Fatalf("LoadSchedules: %v", err)
+	}
+	if n != 1 {
+		t.Fatalf("loaded %d schedules, want 1", n)
+	}
+	got, err := r2.GetSchedule("s1")
+	if err != nil {
+		t.Fatalf("GetSchedule after reload: %v", err)
+	}
+	if got.FlowID != "f1" || got.Cron != "*/5 * * * *" {
+		t.Errorf("reloaded schedule = %+v, want flow f1 cron */5", got)
+	}
+
+	// Removing on the second runner also clears persistence.
+	if err := r2.RemoveSchedule("s1"); err != nil {
+		t.Fatalf("RemoveSchedule: %v", err)
+	}
+	list, _ := store.List(ctx)
+	if len(list) != 0 {
+		t.Fatalf("after remove, store still has %d schedules", len(list))
+	}
+}
+
+// Without a store, schedules remain in memory only (legacy behavior, no error).
+func TestCronRunner_NoStoreIsInMemoryOnly(t *testing.T) {
+	s := runstore.NewMemoryStore(nil)
+	cr := NewCronRunner(New(s, &mockDriver{}, testCommandResolver, nil, slog.Default()),
+		flowstore.NewMemoryStore(), s, slog.Default())
+	if err := cr.AddSchedule(&Schedule{ID: "s1", FlowID: "f1", Cron: "* * * * *", Enabled: true}); err != nil {
+		t.Fatalf("AddSchedule: %v", err)
+	}
+	if n, err := cr.LoadSchedules(context.Background()); err != nil || n != 0 {
+		t.Fatalf("LoadSchedules with no store = (%d, %v), want (0, nil)", n, err)
+	}
+}


### PR DESCRIPTION
## Summary
Completes Slice 5. Cron schedules lived only in an **in-memory map**, so every schedule was lost on orchestrator restart — a rolling deploy silently dropped all scheduled runs.

- New **`ScheduleStore`** abstraction with a **Redis-backed** implementation (a `schedules` hash keyed by id → JSON).
- `CronRunner` persists on `AddSchedule`/`RemoveSchedule` and after each trigger (last-run metadata, so the within-minute dedup from #12 survives a restart). `LoadSchedules()` repopulates the in-memory set at startup.
- Wired into `main`: when `ORCH_RUNSTORE=redis`, the runner gets a Redis schedule store and reloads existing schedules before starting. A **nil store preserves the legacy in-memory-only behavior** (and existing tests).

Assumes a single active orchestrator (consistent with the rest of the cron path); with multiple runners sharing the store each would load and fire independently → duplicate triggers. Documented; gate before multi-replica execution.

## Tests (miniredis)
- store `Save`/`List`/`Delete` round-trip
- a schedule added by one runner is **reloaded by a fresh runner** backed by the same store (restart survival); removal clears persistence
- no-store runners remain in-memory (legacy)
- full `orchestrator-go` suite green (`-race`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)